### PR TITLE
Fix Task failed When Same named Module classes exist in project

### DIFF
--- a/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/KoinGenerator.kt
+++ b/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/KoinGenerator.kt
@@ -65,7 +65,8 @@ class KoinGenerator(
                         defaultFile.generateFieldDefaultModule(module.definitions)
                     }
                     KoinMetaData.ModuleType.CLASS -> {
-                        val moduleFile = codeGenerator.getFile(fileName = "${module.name}Gen")
+                        val fileName = module.generateFileName()
+                        val moduleFile = codeGenerator.getFile(fileName = fileName)
                         generateClassModule(moduleFile, module)
                     }
                 }
@@ -85,6 +86,10 @@ class KoinGenerator(
         lateinit var LOGGER: KSPLogger
             private set
     }
+}
+
+private fun KoinMetaData.Module.generateFileName(): String {
+    return "${this.name}\$${this.packageName.uppercase().replace(".", "\$")}"
 }
 
 private var defaultFile : OutputStream? = null

--- a/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/KoinGenerator.kt
+++ b/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/KoinGenerator.kt
@@ -93,7 +93,7 @@ private fun KoinMetaData.Module.generateFileName(): String {
         .lowercase()
         .split(".")
         .joinToString("$") { it.replaceFirstChar(Char::titlecase) }
-    return if (suffix.isNotEmpty()) "${this.name}\$$suffix" else this.name
+    return if (suffix.isNotBlank()) "${this.name}\$$suffix" else this.name
 }
 
 private var defaultFile : OutputStream? = null

--- a/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/KoinGenerator.kt
+++ b/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/KoinGenerator.kt
@@ -89,7 +89,11 @@ class KoinGenerator(
 }
 
 private fun KoinMetaData.Module.generateFileName(): String {
-    return "${this.name}\$${this.packageName.uppercase().replace(".", "\$")}"
+    val suffix = this.packageName
+        .lowercase()
+        .split(".")
+        .joinToString("$") { it.replaceFirstChar(Char::titlecase) }
+    return if (suffix.isNotEmpty()) "${this.name}\$$suffix" else this.name
 }
 
 private var defaultFile : OutputStream? = null

--- a/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/ModuleGenerationExt.kt
+++ b/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/ModuleGenerationExt.kt
@@ -53,7 +53,7 @@ fun generateClassModule(classFile: OutputStream, module: KoinMetaData.Module) {
 
     val generatedField = "${module.name}Module"
     val classModule = "${module.packageName}.${module.name}"
-    classFile.appendText("\nval $generatedField = module {")
+    classFile.appendText("\nprivate val $generatedField = module {")
 
     if (module.includes?.isNotEmpty() == true) {
         KoinGenerator.LOGGER.logging("generate - includes")

--- a/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/ModuleGenerationExt.kt
+++ b/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/ModuleGenerationExt.kt
@@ -39,6 +39,12 @@ fun OutputStream.generateFieldDefaultModule(definitions: List<KoinMetaData.Defin
 }
 
 fun generateClassModule(classFile: OutputStream, module: KoinMetaData.Module) {
+    classFile.appendText("""
+            @file:JvmName("${module.name}Gen")
+            @file:JvmMultifileClass
+        """.trimIndent())
+    classFile.appendText("\n\n")
+
     classFile.appendText(MODULE_HEADER)
 //    if (module.definitions.any { it.scope != null }) {
 //        classFile.appendText(MODULE_HEADER_STRING_QUALIFIER)


### PR DESCRIPTION
## example

`org/foo/DatabaseConfig.kt`
```kt
package org.foo

@Module
class DatabaseConfig {
    @Single
    fun mariadb(): String = "this is mariadb"
} 
```

will generate this file.

`org/koin/ksp/generated/DatabaseConfig$ORG$FOO.kt`
```kt
@file:JvmName("DataBaseConfigGen")
@file:JvmMultifileClass

package org.koin.ksp.generated
import org.koin.dsl.*

private val DatabaseConfigModule = module {
    val moduleInstance = org.foo.DatabaseConfig()
    single { moduleInstance.mariadb() }
}

val org.foo.DatabaseConfig.module : org.koin.core.module.Module get() = DatabaseConfigModule
```

If you have any better idea to generate file naming strategy. please comment 🙏 

Fixes #14 