### PR TITLE
Add @GetAll for list dependencies. Fixes gh-37

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -146,6 +146,17 @@ class MyComponent(@Property("my_key") val myProperty : String)
 
 The generated DSL equivalent will be `single { MyComponent(getProperty("my_key")) }`
 
+### List parameters with @GetAll
+
+To resolve a dependency with `getAll()` instead of `get()` when dealing with a list, just tag the parameter with @GetAll:
+
+```kotlin
+@Single
+class MyComponent(@GetAll val myDependencies: List<MyDependency>)
+```
+
+The generated DSL equivalent will be `single { MyComponent(getAll()) }`. Without the annotation, it will resolve to `single { MyComponent(get()) }` instead.
+
 ### Declaring Scopes with @Scope
 
 You can declare definition inside a scope, by using the `@Scope` annotation. The target scope can be specified as a class, or a name:

--- a/compiler/koin-annotations/src/commonMain/kotlin/org/koin/core/annotation/CoreAnnotations.kt
+++ b/compiler/koin-annotations/src/commonMain/kotlin/org/koin/core/annotation/CoreAnnotations.kt
@@ -136,6 +136,19 @@ annotation class InjectedParam
 annotation class Property(val value: String)
 
 /**
+ * Annotate a constructor parameter or function parameter, to resolve as "getAll()" instead of "get()"
+ *
+ * example:
+ *
+ * @Factory
+ * class MyClass(@GetAll val dList : List<MyDependency>)
+ *
+ * will result in `factory { MyClass(getAll()) }`
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+annotation class GetAll
+
+/**
  * Class annotation, to help gather definitions inside a Koin module.
  * Each function can be annotated with a Koin definition annotation, to declare it
  *

--- a/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/DefinitionGenerationExt.kt
+++ b/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/DefinitionGenerationExt.kt
@@ -99,6 +99,7 @@ private fun generateConstructor(constructorParameters: List<KoinMetaData.Constru
                 val qualifier = ctorParam.value?.let { "qualifier=org.koin.core.qualifier.StringQualifier(\"${it}\")" } ?: ""
                 if (!isNullable) "get($qualifier)" else "getOrNull($qualifier)"
             }
+            is KoinMetaData.ConstructorParameter.ListDependency -> "getAll()"
             is KoinMetaData.ConstructorParameter.ParameterInject -> if (!isNullable) "params.get()" else "params.getOrNull()"
             is KoinMetaData.ConstructorParameter.Property -> if (!isNullable) "getProperty(\"${ctorParam.value}\")" else "getPropertyOrNull(\"${ctorParam.value}\")"
         }

--- a/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinMetaData.kt
+++ b/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinMetaData.kt
@@ -121,7 +121,7 @@ sealed class KoinMetaData {
     sealed class ConstructorParameter(val nullable: Boolean = false) {
         data class Dependency(val value: String? = null, val isNullable: Boolean = false) :
             ConstructorParameter(isNullable)
-
+        data class ListDependency(val isNullable: Boolean = false) : ConstructorParameter(isNullable)
         data class ParameterInject(val isNullable: Boolean = false) : ConstructorParameter(isNullable)
         data class Property(val value: String? = null, val isNullable: Boolean = false) :
             ConstructorParameter(isNullable)

--- a/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/KspExt.kt
+++ b/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/KspExt.kt
@@ -20,6 +20,7 @@ import org.koin.compiler.metadata.KoinMetaData
 import org.koin.compiler.metadata.isScopeAnnotation
 import org.koin.compiler.metadata.isValidAnnotation
 import org.koin.core.annotation.InjectedParam
+import org.koin.core.annotation.GetAll
 import org.koin.core.annotation.Named
 import org.koin.core.annotation.Property
 
@@ -78,6 +79,7 @@ private fun getConstructorParameter(param: KSValueParameter): KoinMetaData.Const
         "${InjectedParam::class.simpleName}" -> KoinMetaData.ConstructorParameter.ParameterInject(isNullable)
         "${Property::class.simpleName}" -> KoinMetaData.ConstructorParameter.Property(annotationValue, isNullable)
         "${Named::class.simpleName}" -> KoinMetaData.ConstructorParameter.Dependency(annotationValue, isNullable)
+        "${GetAll::class.simpleName}" -> KoinMetaData.ConstructorParameter.ListDependency(isNullable)
         else -> KoinMetaData.ConstructorParameter.Dependency(isNullable = isNullable)
     }
 }

--- a/quickstart/quickstart-kotlin-annotations/src/main/kotlin/org/koin/sample/coffee/component/CoffeeMaker.kt
+++ b/quickstart/quickstart-kotlin-annotations/src/main/kotlin/org/koin/sample/coffee/component/CoffeeMaker.kt
@@ -1,13 +1,15 @@
 package org.koin.sample.coffee.component
 
+import org.koin.core.annotation.GetAll
 import org.koin.core.annotation.Single
 
 @Single
-class CoffeeMaker(private val pump: Pump, private val heater: Heater) {
+class CoffeeMaker(private val pump: Pump, private val heater: Heater, @GetAll private val dispensers: List<Dispenser>) {
 
     fun brew() {
         heater.on()
         pump.pump()
+        dispensers.forEach(Dispenser::dispense)
         println(" [_]P coffee! [_]P ")
         heater.off()
     }

--- a/quickstart/quickstart-kotlin-annotations/src/main/kotlin/org/koin/sample/coffee/component/Dispenser.kt
+++ b/quickstart/quickstart-kotlin-annotations/src/main/kotlin/org/koin/sample/coffee/component/Dispenser.kt
@@ -1,0 +1,6 @@
+package org.koin.sample.coffee.component
+
+interface Dispenser {
+
+    fun dispense()
+}

--- a/quickstart/quickstart-kotlin-annotations/src/main/kotlin/org/koin/sample/coffee/component/MilkDispenser.kt
+++ b/quickstart/quickstart-kotlin-annotations/src/main/kotlin/org/koin/sample/coffee/component/MilkDispenser.kt
@@ -1,0 +1,11 @@
+package org.koin.sample.coffee.component
+
+import org.koin.core.annotation.Single
+
+@Single
+class MilkDispenser : Dispenser {
+
+    override fun dispense() {
+        println("Adding milk to coffee")
+    }
+}

--- a/quickstart/quickstart-kotlin-annotations/src/main/kotlin/org/koin/sample/coffee/component/SugarDispenser.kt
+++ b/quickstart/quickstart-kotlin-annotations/src/main/kotlin/org/koin/sample/coffee/component/SugarDispenser.kt
@@ -1,0 +1,11 @@
+package org.koin.sample.coffee.component
+
+import org.koin.core.annotation.Single
+
+@Single
+class SugarDispenser : Dispenser {
+
+    override fun dispense() {
+        println("Adding sugar to coffee")
+    }
+}


### PR DESCRIPTION
If a parameter is of type List, the default behaviour is to fill it with get(). Sometimes a getAll() is required instead. @GetAll provides this possibility.