### PR TITLE
Fix source set configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ implementation "io.insert-koin:koin-annotations:$koin_annotations_version"
 ksp "io.insert-koin:koin-ksp-compiler:$koin_annotations_version"
 ```
 
-On your app add the following to generated source code:
+On your app add the following to see generated source code:
 
 * On Kotlin project:
 
@@ -46,11 +46,13 @@ sourceSets.main {
 
 ```groovy
 android {
-  applicationVariants.all { variant ->
-          variant.sourceSets.java.each {
-              it.srcDirs += "build/generated/ksp/${variant.name}/kotlin"
-          }
-      }
+    applicationVariants.configureEach { variant ->
+        kotlin.sourceSets {
+            getByName(name) {
+                kotlin.srcDir("build/generated/ksp/${variant.name}/kotlin")
+            }
+        }
+    }
 }
 ```
 

--- a/quickstart/quickstart-android-annotations/app/build.gradle
+++ b/quickstart/quickstart-android-annotations/app/build.gradle
@@ -17,9 +17,11 @@ android {
         test.java.srcDirs += 'src/test/kotlin'
     }
     // For KSP
-    applicationVariants.all { variant ->
-        variant.sourceSets.java.each {
-            it.srcDirs += "build/generated/ksp/${variant.name}/kotlin"
+    applicationVariants.configureEach { variant ->
+        kotlin.sourceSets {
+            getByName(name) {
+                kotlin.srcDir("build/generated/ksp/${variant.name}/kotlin")
+            }
         }
     }
 }


### PR DESCRIPTION
Using `configureEach` instead of `all` is much better. It's not required to clean project between flavor changes anymore.