### PR TITLE
Fix missing parents for nested classes. Fixes gh-40

### DIFF
--- a/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/DefinitionGenerationExt.kt
+++ b/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/DefinitionGenerationExt.kt
@@ -74,7 +74,25 @@ private fun generateBindings(bindings: List<KSDeclaration>): String {
 private fun generateBinding(declaration: KSDeclaration): String {
     val packageName = declaration.packageName.asString()
     val className = declaration.simpleName.asString()
-    return "$packageName.$className::class"
+    val parents = getParentDeclarations(declaration)
+    return if (parents.isNotEmpty()) {
+        val parentNames = parents.joinToString(".") { it.simpleName.asString() }
+        "$packageName.$parentNames.$className::class"
+    } else {
+        "$packageName.$className::class"
+    }
+}
+
+private fun getParentDeclarations(declaration: KSDeclaration): List<KSDeclaration> {
+    val parents = mutableListOf<KSDeclaration>()
+
+    var parent = declaration.parentDeclaration
+    while (parent != null) {
+        parents.add(parent)
+        parent = parent.parentDeclaration
+    }
+
+    return parents.reversed()
 }
 
 fun generateScope(scope: KoinMetaData.Scope): String {


### PR DESCRIPTION
This fixes #40. It adds nested class binding by adding all outer classes to the import path.