### PR TITLE
Allow empty but including modules to be generated

### DIFF
--- a/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/KoinGenerator.kt
+++ b/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/KoinGenerator.kt
@@ -52,7 +52,7 @@ class KoinGenerator(
 
     private fun generateModule(module: KoinMetaData.Module) {
         logger.logging("generate $module - ${module.type}")
-        if (module.definitions.isNotEmpty()) {
+        if (module.definitions.isNotEmpty() || module.includes?.isNotEmpty() == true) {
             when (module.type) {
                 KoinMetaData.ModuleType.FIELD -> {
                     codeGenerator.getDefaultFile().generateFieldDefaultModule(module.definitions)


### PR DESCRIPTION
If you create a module with no definitions but that includes another module, it won't be generated. This isn't that useful for modules that are only used to organize other submodules together. 