### PR TITLE
Added missing imports in Module. Fixes GH-51.

### DIFF
--- a/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/Templates.kt
+++ b/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/Templates.kt
@@ -39,6 +39,8 @@ fun moduleHeader(genName : String) = """
     @file:JvmMultifileClass
     package org.koin.ksp.generated
     
+    import kotlin.jvm.JvmMultifileClass
+    import kotlin.jvm.JvmName
     import org.koin.dsl.*
     
 """.trimIndent()


### PR DESCRIPTION
Without these imports, compilation fails when attempting to compile with a native target.

```
[someModuleName].kt: (1, 7): Unresolved reference: JvmName
[someModuleName].kt: (2, 7): Unresolved reference: JvmMultifileClass
```

Related issue: https://github.com/InsertKoinIO/koin-annotations/issues/51