### PR TITLE
Added basic support for Multiple Round Processing

### DIFF
--- a/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
+++ b/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
@@ -22,24 +22,39 @@ import org.koin.compiler.metadata.KoinMetaData
 import org.koin.compiler.scanner.KoinMetaDataScanner
 
 class BuilderProcessor(
-    private val codeGenerator: CodeGenerator,
+    codeGenerator: CodeGenerator,
     private val logger: KSPLogger
 ) : SymbolProcessor {
 
     private val koinCodeGenerator = KoinGenerator(codeGenerator, logger)
     private val koinMetaDataScanner = KoinMetaDataScanner(logger)
 
+    private var codeGenerated = false
+
     override fun process(resolver: Resolver): List<KSAnnotated> {
+        if (codeGenerated) {
+            return emptyList()
+        }
+
+        logger.logging("Scanning symbols ...")
+        val invalidSymbols = koinMetaDataScanner.scanSymbols(resolver)
+        if (invalidSymbols.isNotEmpty()) {
+            logger.logging("Invalid symbols found (${invalidSymbols.size}), waiting second round")
+            return invalidSymbols
+        }
+
         val defaultModule = KoinMetaData.Module(
             packageName = "",
             name = "defaultModule"
         )
 
         logger.logging("Scan metadata ...")
-        val moduleList = koinMetaDataScanner.scanAllMetaData(resolver, defaultModule)
+        val moduleList = koinMetaDataScanner.scanAllMetaData(defaultModule)
 
         logger.logging("Generate code ...")
         koinCodeGenerator.generateModules(moduleList, defaultModule)
+        codeGenerated = true
+
         return emptyList()
     }
 }


### PR DESCRIPTION
This PR objective is to add basic support for KSP Multiple Round Processing. (https://kotlinlang.org/docs/ksp-multi-round.html)

The issue it tries to solve is that if the Koin Compiler is used alongside another KSP-based compiler, Koin may generate incomplete module code. For instance if a class annotated for Koin requires the result of another compiler to become "valid".

The contract of a `SymbolProcessor` states thaf if it returns a List of invalid annotated entites, KSP will re-call the processor later, including any code generated by other processors during round one.

To achieve that, the `KoinMetaDataScanner` job was split in two parts.

1. It scans for module and definition symbols. If it finds any invalid entity, it returns the list and the processing ends there. All valid entites are kept for next round.
2. After second round symbol scanning is successful, it `scansAllMetaData`, as before.

Note: The `codeGenerated` flag is required, since the termination condition of multiple round processing is _when a full round of processing generates no new files._ This means that the processor will be called a third time (since round two generated the code). But the `CodeGenerator` fails if called more than once. So in that case we simply early return since we consider the job aleady done.

Testing: I've been using this code in two different projects for a while using my local fork.

