### PR TITLE
Preserve module visibility

### DIFF
--- a/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/ModuleGenerationExt.kt
+++ b/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/ModuleGenerationExt.kt
@@ -53,7 +53,10 @@ fun generateClassModule(classFile: OutputStream, module: KoinMetaData.Module) {
     generateDefinitions(module, classFile)
 
     classFile.appendText("\n}")
-    classFile.appendText("\nval $modulePath.module : org.koin.core.module.Module get() = $generatedField")
+    val visibilityString = module.visibility.toSourceString()
+    classFile.appendText(
+        "\n${visibilityString}val $modulePath.module : org.koin.core.module.Module get() = $generatedField"
+    )
 
     classFile.flush()
     classFile.close()
@@ -101,7 +104,8 @@ private fun KoinMetaData.Module.generateModuleField(
 ): String {
     val packageName = packageName("_")
     val generatedField = "${packageName}_${name}"
-    classFile.appendText("\nval $generatedField = module {")
+    val visibilityString = visibility.toSourceString()
+    classFile.appendText("\n${visibilityString}val $generatedField = module {")
     return generatedField
 }
 

--- a/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/Utils.kt
+++ b/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/Utils.kt
@@ -13,10 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import com.google.devtools.ksp.symbol.Visibility
 import java.io.OutputStream
 
 fun String.dotPackage() = if (isNotBlank()) "$this." else ""
 
 fun OutputStream.appendText(str: String) {
     this.write(str.toByteArray())
+}
+
+fun Visibility.toSourceString() = when(this) {
+    Visibility.PUBLIC -> "public "
+    Visibility.INTERNAL -> "internal "
+    Visibility.PRIVATE -> "private "
+    Visibility.PROTECTED -> "protected "
+    else -> ""
 }

--- a/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinMetaData.kt
+++ b/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinMetaData.kt
@@ -16,6 +16,7 @@
 package org.koin.compiler.metadata
 
 import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.Visibility
 import java.util.*
 
 sealed class KoinMetaData {
@@ -26,7 +27,8 @@ sealed class KoinMetaData {
         val definitions: MutableList<Definition> = mutableListOf(),
         val type: ModuleType = ModuleType.FIELD,
         val componentScan: ComponentScan? = null,
-        val includes : List<KSDeclaration>? = null
+        val includes : List<KSDeclaration>? = null,
+        val visibility: Visibility = Visibility.PUBLIC,
     ) : KoinMetaData() {
 
         fun packageName(separator : String) : String{

--- a/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/ModuleScanner.kt
+++ b/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/ModuleScanner.kt
@@ -15,6 +15,7 @@
  */
 package org.koin.compiler.scanner
 
+import com.google.devtools.ksp.getVisibility
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.*
 import org.koin.compiler.metadata.*
@@ -36,7 +37,8 @@ class ModuleScanner(
             name = name,
             type = KoinMetaData.ModuleType.CLASS,
             componentScan = componentScan,
-            includes = includes
+            includes = includes,
+            visibility = declaration.getVisibility()
         )
 
         val annotatedFunctions = declaration.getAllFunctions()


### PR DESCRIPTION
## Preserve the visibility of module classes in generated sources.

### Problem
Generated module fields and extension properties always have (implicit) public visibility.
If a module class has `internal` visibility, this causes an `'public' member exposes its 'internal' receiver type <type>` compiler error

### Implementation
Explicitly add the visibility of the module class to the generated field and extension property.