### PR TITLE
Fix multiple round pass issue #66

### DIFF
--- a/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
+++ b/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
@@ -28,18 +28,11 @@ class BuilderProcessor(
 
     private val koinCodeGenerator = KoinGenerator(codeGenerator, logger)
     private val koinMetaDataScanner = KoinMetaDataScanner(logger)
-
-    private var codeGenerated = false
-
     override fun process(resolver: Resolver): List<KSAnnotated> {
-        if (codeGenerated) {
-            return emptyList()
-        }
-
         logger.logging("Scanning symbols ...")
         val invalidSymbols = koinMetaDataScanner.scanSymbols(resolver)
         if (invalidSymbols.isNotEmpty()) {
-            logger.logging("Invalid symbols found (${invalidSymbols.size}), waiting second round")
+            logger.logging("Invalid symbols found (${invalidSymbols.size}), waiting for next round")
             return invalidSymbols
         }
 
@@ -53,7 +46,6 @@ class BuilderProcessor(
 
         logger.logging("Generate code ...")
         koinCodeGenerator.generateModules(moduleList, defaultModule)
-        codeGenerated = true
 
         return emptyList()
     }


### PR DESCRIPTION
This PR removes the "stop processing" flag since there might be some code to process that was not available in the first round of ksp processing.

For example: Koin was able to successfully do a first round, where the compiler found `@Module` and `@ComponentScan`. The code was generated and the `codeGenerated` flag was set to true. The issue is that some other ksp processor did generate a new class during the first round. The new class has `@Single` annotation, but it was ignored since the `codeGenerated` flag was shutting further processing down.

This fix makes the processor able to do multiple rounds on the same symbols and recreating generated modules file contents if necessary.

Fixes #66 