### PR TITLE
Feature: support constructor with default arguments

### DIFF
--- a/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/DefinitionGenerationExt.kt
+++ b/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/DefinitionGenerationExt.kt
@@ -120,7 +120,8 @@ fun generateScope(scope: KoinMetaData.Scope): String {
 fun generateScopeClosing(): String = "${NEW_LINE}}"
 
 private fun generateConstructor(constructorParameters: List<KoinMetaData.ConstructorParameter>): String {
-    return constructorParameters.joinToString(prefix = "(", separator = ",", postfix = ")") { ctorParam ->
+    val paramsWithoutDefaultValues = constructorParameters.filter { !it.hasDefault }
+    return paramsWithoutDefaultValues.joinToString(prefix = "(", separator = ",", postfix = ")") { ctorParam ->
         val isNullable: Boolean = ctorParam.nullable
         when (ctorParam) {
             is KoinMetaData.ConstructorParameter.Dependency -> {

--- a/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/DefinitionGenerationExt.kt
+++ b/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/DefinitionGenerationExt.kt
@@ -132,7 +132,8 @@ private fun generateConstructor(constructorParameters: List<KoinMetaData.Constru
                         val qualifier =
                             ctorParam.value?.let { "qualifier=org.koin.core.qualifier.StringQualifier(\"${it}\")" }
                                 ?: ""
-                        if (!isNullable) "$keyword($qualifier)" else "${keyword}OrNull($qualifier)"
+                        val operator = if (!isNullable) "$keyword($qualifier)" else "${keyword}OrNull($qualifier)"
+                        if (ctorParam.name == null) operator else "${ctorParam.name}=$operator"
                     }
                 }
             }

--- a/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinMetaData.kt
+++ b/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinMetaData.kt
@@ -123,12 +123,31 @@ sealed class KoinMetaData {
     }
 
     sealed class ConstructorParameter(val nullable: Boolean = false) {
-        data class Dependency(val value: String? = null, val isNullable: Boolean = false, val kind : DependencyKind = DependencyKind.Single) :
-            ConstructorParameter(isNullable)
 
-        data class ParameterInject(val isNullable: Boolean = false) : ConstructorParameter(isNullable)
-        data class Property(val value: String? = null, val isNullable: Boolean = false) :
-            ConstructorParameter(isNullable)
+        abstract val name: String?
+        abstract val hasDefault: Boolean
+
+        data class Dependency(
+            override val name: String?,
+            val value: String? = null,
+            val isNullable: Boolean = false,
+            override val hasDefault: Boolean,
+            val kind: DependencyKind = DependencyKind.Single
+        ) : ConstructorParameter(isNullable)
+
+
+        data class ParameterInject(
+            override val name: String?,
+            val isNullable: Boolean = false,
+            override val hasDefault: Boolean
+        ) : ConstructorParameter(isNullable)
+
+        data class Property(
+            override val name: String?,
+            val value: String? = null,
+            val isNullable: Boolean = false,
+            override val hasDefault: Boolean
+        ) : ConstructorParameter(isNullable)
     }
 
     enum class DependencyKind {

--- a/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/KspExt.kt
+++ b/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/KspExt.kt
@@ -73,21 +73,23 @@ private fun getConstructorParameter(param: KSValueParameter): KoinMetaData.Const
     val firstAnnotation = param.annotations.firstOrNull()
     val annotationName = firstAnnotation?.shortName?.asString()
     val annotationValue = firstAnnotation?.arguments?.getValueArgument()
+    val paramName = param.name?.asString()
     val resolvedType = param.type.resolve()
     val isNullable = resolvedType.isMarkedNullable
+    val hasDefault = param.hasDefault
     val resolvedTypeString = resolvedType.toString()
     //TODO check to see better way to detect this
     val isList = resolvedTypeString.startsWith("List<")
     val isLazy = resolvedTypeString.startsWith("Lazy<")
 
     return when (annotationName) {
-        "${InjectedParam::class.simpleName}" -> KoinMetaData.ConstructorParameter.ParameterInject(isNullable)
-        "${Property::class.simpleName}" -> KoinMetaData.ConstructorParameter.Property(annotationValue, isNullable)
-        "${Named::class.simpleName}" -> KoinMetaData.ConstructorParameter.Dependency(annotationValue, isNullable)
+        "${InjectedParam::class.simpleName}" -> KoinMetaData.ConstructorParameter.ParameterInject(name = paramName, isNullable = isNullable, hasDefault = hasDefault)
+        "${Property::class.simpleName}" -> KoinMetaData.ConstructorParameter.Property(name = paramName, value = annotationValue, isNullable, hasDefault)
+        "${Named::class.simpleName}" -> KoinMetaData.ConstructorParameter.Dependency(name = paramName, value = annotationValue, isNullable, hasDefault)
         else -> {
-            if (isList) KoinMetaData.ConstructorParameter.Dependency(kind = KoinMetaData.DependencyKind.List)
-            else if (isLazy) KoinMetaData.ConstructorParameter.Dependency(isNullable = isNullable, kind = KoinMetaData.DependencyKind.Lazy)
-            else KoinMetaData.ConstructorParameter.Dependency(isNullable = isNullable)
+            if (isList) KoinMetaData.ConstructorParameter.Dependency(name = paramName, hasDefault = hasDefault, kind = KoinMetaData.DependencyKind.List)
+            else if (isLazy) KoinMetaData.ConstructorParameter.Dependency(name = paramName, isNullable = isNullable, hasDefault = hasDefault, kind = KoinMetaData.DependencyKind.Lazy)
+            else KoinMetaData.ConstructorParameter.Dependency(name = paramName, isNullable = isNullable, hasDefault = hasDefault)
         }
     }
 }

--- a/sandbox/other-ksp/src/main/kotlin/org/koin/example/newmodule/ComponentWithDefaultValues.kt
+++ b/sandbox/other-ksp/src/main/kotlin/org/koin/example/newmodule/ComponentWithDefaultValues.kt
@@ -1,0 +1,13 @@
+package org.koin.example.newmodule
+
+import org.koin.core.annotation.Single
+
+interface ComponentInterface {
+
+    companion object Default : ComponentInterface
+}
+
+@Single
+class ComponentWithDefaultValues(
+    private val dependency: ComponentInterface = ComponentInterface.Default
+)

--- a/sandbox/other-ksp/src/test/kotlin/org.koin.example/TestModule.kt
+++ b/sandbox/other-ksp/src/test/kotlin/org.koin.example/TestModule.kt
@@ -4,6 +4,7 @@ import org.junit.Test
 import org.koin.core.context.startKoin
 import org.koin.core.logger.Level
 import org.koin.example.`interface`.MyInterfaceExt
+import org.koin.example.newmodule.ComponentWithDefaultValues
 import org.koin.example.newmodule.MyModule2
 import org.koin.example.newmodule.MyOtherComponent2
 import org.koin.example.newmodule.mymodule.MyModule3
@@ -27,5 +28,6 @@ class TestModule {
         koin.get<MyOtherComponent>()
         koin.get<MyOtherComponent2>()
         koin.get<MyOtherComponent3>()
+        koin.get<ComponentWithDefaultValues>()
     }
 }


### PR DESCRIPTION
## Description

This PR implements the requested feature of skipping constructor parameters that are declared with a default value (https://github.com/InsertKoinIO/koin-annotations/issues/54).

Changelist:
- Add `name` and `hasDefault` values to the `KoinMetaData.ConstructorParameter` class to keep track of those info during code generation;
- Filter out constructor parameters that have a default value;
- Add the param name when generating the definition to disambiguate when parameters with default values are places between others that don't have default values.