### PR TITLE
Fixed multiple round processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ![logo](https://github.com/InsertKoinIO/koin/blob/main/docs/img/koin_main_logo.png)
 
-[![Kotlin](https://img.shields.io/badge/Kotlin-1.7.21-blue.svg?style=flat&logo=kotlin)](https://kotlinlang.org)
-![Github Actions](https://github.com/InsertKoinIO/koin-annotations/actions/workflows/build.yml/badge.svg)
+[![Kotlin](https://img.shields.io/badge/Kotlin-1.8.10-blue.svg?style=flat&logo=kotlin)](https://kotlinlang.org)
 [![Apache 2 License](https://img.shields.io/github/license/InsertKoinIO/koin)](https://github.com/InsertKoinIO/koin/blob/main/LICENSE.txt)
 [![Slack channel](https://img.shields.io/badge/Chat-Slack-orange.svg?style=flat&logo=slack)](https://kotlinlang.slack.com/messages/koin/)
 

--- a/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/KoinMetaDataScanner.kt
+++ b/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/KoinMetaDataScanner.kt
@@ -42,6 +42,9 @@ class KoinMetaDataScanner(
             resolver.getSymbolsWithAnnotation(annotation.qualifiedName!!)
         }
 
+        validModuleSymbols.addAll(moduleSymbols.filter { it.validate() })
+        validDefinitionSymbols.addAll(definitionSymbols.filter { it.validate() })
+
         val invalidModuleSymbols = moduleSymbols.filter { !it.validate() }
         val invalidDefinitionSymbols = definitionSymbols.filter { !it.validate() }
         val invalidSymbols = invalidModuleSymbols + invalidDefinitionSymbols
@@ -50,9 +53,6 @@ class KoinMetaDataScanner(
             logInvalidEntities(invalidSymbols)
             return invalidSymbols
         }
-
-        validModuleSymbols.addAll(moduleSymbols.filter { it.validate() })
-        validDefinitionSymbols.addAll(definitionSymbols.filter { it.validate() })
 
         logger.logging("All symbols are valid")
         return emptyList()

--- a/sandbox/android-coffee-maker/build.gradle.kts
+++ b/sandbox/android-coffee-maker/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 }
 
 android {
-    compileSdkVersion(32)
+    compileSdkVersion(33)
     defaultConfig {
         applicationId = "org.gradle.kotlin.dsl.samples.androidstudio"
         minSdkVersion(21)

--- a/sandbox/android-library/build.gradle.kts
+++ b/sandbox/android-library/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 }
 
 android {
-    compileSdkVersion(32)
+    compileSdkVersion(33)
     defaultConfig {
         minSdkVersion(21)
     }


### PR DESCRIPTION
Valid symbols must be kept between rounds since they won't be sent again by KSP.

This was accidentally broken in a cleanup commit: https://github.com/InsertKoinIO/koin-annotations/commit/b386438a740219e0b456b8928463b816e617babc

When returning some invalid entities to KSP for next processing round, it is important to keep the valid ones, since during next round only new and previously invalid entities will be provided by KSP. 

@jakoss You may be interested / have an opinion, since you did some changes in that section too.