### PR TITLE
Use Unit::class as a default value of KClass parameter in annotation

### DIFF
--- a/compiler/koin-annotations/src/commonMain/kotlin/org/koin/core/annotation/CoreAnnotations.kt
+++ b/compiler/koin-annotations/src/commonMain/kotlin/org/koin/core/annotation/CoreAnnotations.kt
@@ -87,8 +87,7 @@ annotation class Factory(val binds: Array<KClass<*>> = [])
  * @param name: scope string value
  */
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
-annotation class Scope(val value: KClass<*> = NoClass::class, val name: String = "")
-private object NoClass
+annotation class Scope(val value: KClass<*> = Unit::class, val name: String = "")
 
 /**
  * Declare a type, a function as `scoped` definition in Koin. Must be associated with @Scope annotation

--- a/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/KspExt.kt
+++ b/compiler/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/KspExt.kt
@@ -50,7 +50,7 @@ fun List<KSValueArgument>.getScope(): KoinMetaData.Scope {
     val scopeStringType: String? = firstOrNull { it.name?.asString() == "name" }?.value as? String
     return scopeKClassType?.let {
         val type = it.declaration
-        if (type.simpleName.asString() != "NoClass") {
+        if (type.simpleName.asString() != "Unit") {
             KoinMetaData.Scope.ClassScope(type)
         } else null
     }

--- a/sandbox/android-coffee-maker/build.gradle.kts
+++ b/sandbox/android-coffee-maker/build.gradle.kts
@@ -17,9 +17,10 @@ repositories {
 }
 
 android {
-    compileSdkVersion(32)
+    compileSdkVersion(33)
     defaultConfig {
         applicationId = "org.gradle.kotlin.dsl.samples.androidstudio"
+        targetSdkVersion(33)
         minSdkVersion(21)
         versionCode = 1
         versionName = "1.0"

--- a/sandbox/android-library/build.gradle.kts
+++ b/sandbox/android-library/build.gradle.kts
@@ -17,8 +17,9 @@ repositories {
 }
 
 android {
-    compileSdkVersion(32)
+    compileSdkVersion(33)
     defaultConfig {
+        targetSdkVersion(33)
         minSdkVersion(21)
     }
     // to use KSP generated Code


### PR DESCRIPTION
I'm doing a little bit of processing in another project and when i try to pass the `AnnotationSpec` of koin `Scope` annotation i get an error that i cannot use private class as a default value of a parameter in annotation. Since we can use `Unit` just fine in this place it seems like an easy and safe change