### PR TITLE
Add KOIN_VIEWMODEL_KMP for support KMP ViewModel

### DIFF
--- a/projects/koin-annotations/src/commonMain/kotlin/org/koin/core/annotation/CoreAnnotations.kt
+++ b/projects/koin-annotations/src/commonMain/kotlin/org/koin/core/annotation/CoreAnnotations.kt
@@ -184,3 +184,21 @@ annotation class Module(val includes: Array<KClass<*>> = [], val createdAtStart:
  */
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FIELD)
 annotation class ComponentScan(val value: String = "")
+
+/**
+ * ViewModel annotation for Koin definition
+ * Declare a type, a function as `viewModel` definition in Koin
+ *
+ * example:
+ *
+ * @KoinViewModel
+ * class MyViewModel(val d : MyDependency) : ViewModel()
+ *
+ * will result in `viewModel { MyViewModel(get()) }`
+ *
+ * All dependencies are filled by constructor.
+ *
+ * @param binds: declared explicit types to bind to this definition. Supertypes are automatically detected
+ */
+@Target(AnnotationTarget.CLASS,AnnotationTarget.FUNCTION)
+annotation class KoinViewModel(val binds: Array<KClass<*>> = [])

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/AnnotationMetadata.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/AnnotationMetadata.kt
@@ -18,7 +18,6 @@ package org.koin.compiler.metadata
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSType
-import org.koin.android.annotation.KoinViewModel
 import org.koin.android.annotation.KoinWorker
 import org.koin.compiler.generator.KoinGenerator.Companion.LOGGER
 import org.koin.core.annotation.*
@@ -38,14 +37,15 @@ val SINGLETON = DefinitionAnnotation("single", annotationType = Singleton::class
 val FACTORY = DefinitionAnnotation("factory", annotationType = Factory::class)
 val SCOPE = DefinitionAnnotation("scoped", annotationType = Scope::class)
 val SCOPED = DefinitionAnnotation("scoped", annotationType = Scoped::class)
-val KOIN_VIEWMODEL = DefinitionAnnotation("viewModel", "org.koin.androidx.viewmodel.dsl.viewModel", KoinViewModel::class)
+val KOIN_VIEWMODEL = DefinitionAnnotation("viewModel", "org.koin.androidx.viewmodel.dsl.viewModel", org.koin.android.annotation.KoinViewModel::class)
+val KOIN_VIEWMODEL_KMP = DefinitionAnnotation("viewModel", "org.koin.compose.viewmodel.dsl.viewModel", KoinViewModel::class)
 val KOIN_WORKER = DefinitionAnnotation("worker", "org.koin.androidx.workmanager.dsl.worker", KoinWorker::class)
 
-val DEFINITION_ANNOTATION_LIST = listOf(SINGLE, SINGLETON,FACTORY, SCOPE, SCOPED,KOIN_VIEWMODEL, KOIN_WORKER)
+val DEFINITION_ANNOTATION_LIST = listOf(SINGLE, SINGLETON,FACTORY, SCOPE, SCOPED,KOIN_VIEWMODEL, KOIN_VIEWMODEL_KMP, KOIN_WORKER)
 val DEFINITION_ANNOTATION_LIST_TYPES = DEFINITION_ANNOTATION_LIST.map { it.annotationType }
 val DEFINITION_ANNOTATION_LIST_NAMES = DEFINITION_ANNOTATION_LIST.map { it.annotationName?.lowercase(Locale.getDefault()) }
 
-val SCOPE_DEFINITION_ANNOTATION_LIST = listOf(SCOPED, FACTORY, KOIN_VIEWMODEL, KOIN_WORKER)
+val SCOPE_DEFINITION_ANNOTATION_LIST = listOf(SCOPED, FACTORY, KOIN_VIEWMODEL, KOIN_VIEWMODEL_KMP, KOIN_WORKER)
 val SCOPE_DEFINITION_ANNOTATION_LIST_NAMES = SCOPE_DEFINITION_ANNOTATION_LIST.map { it.annotationName?.lowercase(Locale.getDefault()) }
 
 
@@ -59,6 +59,7 @@ fun getExtraScopeAnnotation(annotations: Map<String, KSAnnotation>): DefinitionA
         SCOPED.annotationName -> SCOPED
         FACTORY.annotationName -> FACTORY
         KOIN_VIEWMODEL.annotationName -> KOIN_VIEWMODEL
+        KOIN_VIEWMODEL_KMP.annotationName -> KOIN_VIEWMODEL_KMP
         KOIN_WORKER.annotationName -> KOIN_WORKER
         else -> null
     }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/ClassComponentScanner.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/ClassComponentScanner.kt
@@ -67,6 +67,9 @@ class ClassComponentScanner(
             KOIN_VIEWMODEL.annotationName -> {
                 createClassDefinition(KOIN_VIEWMODEL,packageName, qualifier, className, ctorParams, allBindings)
             }
+            KOIN_VIEWMODEL_KMP.annotationName -> {
+                createClassDefinition(KOIN_VIEWMODEL_KMP,packageName, qualifier, className, ctorParams, allBindings)
+            }
             KOIN_WORKER.annotationName -> {
                 createClassDefinition(KOIN_WORKER,packageName, qualifier, className, ctorParams, allBindings)
             }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/FunctionScanner.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/FunctionScanner.kt
@@ -56,6 +56,9 @@ abstract class FunctionScanner(
             KOIN_VIEWMODEL.annotationName -> {
                 createDefinition(KOIN_VIEWMODEL,packageName,qualifier,functionName,functionParameters,allBindings)
             }
+            KOIN_VIEWMODEL_KMP.annotationName -> {
+                createDefinition(KOIN_VIEWMODEL_KMP,packageName,qualifier,functionName,functionParameters,allBindings)
+            }
             KOIN_WORKER.annotationName -> {
                 createDefinition(KOIN_WORKER,packageName,qualifier,functionName,functionParameters,allBindings)
             }


### PR DESCRIPTION
# Summary

I added new KoinViewModel annotation for supporting KMP

# Content

with koin-annotations:1.3.1 and lifecycle-viewmodel:2.0.0, generated kt file use org.koin.compose.viewmodel.dsl.viewModel rather than  org.koin.androidx.viewmodel.dsl.viewModel.

because Koin-annotation compiler can't know version of lifecycle-viewmodel's version, I added org.koin.compose.viewmodel.dsl.viewModel for koinViewModel with KMP.

# Implementation

I added KOIN_VIEWMODEL_KMP as new Definition Annotation

# Example 

below is exampled of generated Kotlin file

> ASIS 

```
package org.koin.ksp.generated

import org.koin.core.module.Module
import org.koin.dsl.*
import org.koin.androidx.viewmodel.dsl.viewModel

public val com_bravepeople_devevent_feature_bookmark_BookmarkModule : Module = module {
	viewModel() { com.bravepeople.devevent.feature.bookmark.BookmarkEventViewModel(getBookmarkEventUseCase=get(),unBookmarkEventUseCase=get(),deleteAllEventBookmarkUseCase=get()) } 
}
public val com.bravepeople.devevent.feature.bookmark.BookmarkModule.module : org.koin.core.module.Module get() = com_bravepeople_devevent_feature_bookmark_BookmarkModule
```

TOBE
```
package org.koin.ksp.generated

import org.koin.core.module.Module
import org.koin.dsl.*
import org.koin.compose.viewmodel.dsl.viewModel

public val com_bravepeople_devevent_feature_bookmark_BookmarkModule : Module = module {
	viewModel() { com.bravepeople.devevent.feature.bookmark.BookmarkEventViewModel(getBookmarkEventUseCase=get(),unBookmarkEventUseCase=get(),deleteAllEventBookmarkUseCase=get()) } 
}
public val com.bravepeople.devevent.feature.bookmark.BookmarkModule.module : org.koin.core.module.Module get() = com_bravepeople_devevent_feature_bookmark_BookmarkModule
```