### PR TITLE
Multimodule scan for definitions

### DIFF
--- a/examples/android-coffee-maker/build.gradle.kts
+++ b/examples/android-coffee-maker/build.gradle.kts
@@ -48,5 +48,5 @@ dependencies {
 
 ksp {
     arg("KOIN_CONFIG_CHECK","true")
-    arg("KOIN_DEFAULT_MODULE","false")
+//    arg("KOIN_DEFAULT_MODULE","false")
 }

--- a/examples/android-coffee-maker/src/test/java/AndroidModuleTest.kt
+++ b/examples/android-coffee-maker/src/test/java/AndroidModuleTest.kt
@@ -8,6 +8,7 @@ import org.koin.sample.android.library.CommonRepository
 import org.koin.sample.android.library.MyScope
 import org.koin.sample.androidx.app.ScopedStuff
 import org.koin.sample.androidx.data.DataConsumer
+import org.koin.sample.androidx.data.MyDataConsumer
 import org.koin.sample.androidx.di.AppModule
 import org.koin.sample.androidx.di.DataModule
 import org.koin.sample.androidx.repository.RepositoryModule
@@ -33,6 +34,7 @@ class AndroidModuleTest {
         scope.get<ScopedStuff>()
 
         assert(koin.getOrNull<DataConsumer>() != null)
+        assert(koin.getOrNull<MyDataConsumer>() != null)
 
         stopKoin()
     }

--- a/examples/android-coffee-maker/src/test/java/AndroidModuleTest.kt
+++ b/examples/android-coffee-maker/src/test/java/AndroidModuleTest.kt
@@ -7,6 +7,7 @@ import org.koin.ksp.generated.module
 import org.koin.sample.android.library.CommonRepository
 import org.koin.sample.android.library.MyScope
 import org.koin.sample.androidx.app.ScopedStuff
+import org.koin.sample.androidx.data.DataConsumer
 import org.koin.sample.androidx.di.AppModule
 import org.koin.sample.androidx.di.DataModule
 import org.koin.sample.androidx.repository.RepositoryModule
@@ -30,6 +31,8 @@ class AndroidModuleTest {
 
         val scope = koin.createScope<MyScope>()
         scope.get<ScopedStuff>()
+
+        assert(koin.getOrNull<DataConsumer>() != null)
 
         stopKoin()
     }

--- a/examples/android-library/build.gradle.kts
+++ b/examples/android-library/build.gradle.kts
@@ -35,4 +35,5 @@ dependencies {
 
 ksp {
     arg("KOIN_CONFIG_CHECK","true")
+//    arg("KOIN_DEFAULT_MODULE","false")
 }

--- a/examples/android-library/src/main/java/org/koin/sample/androidx/data/DataConsumer.kt
+++ b/examples/android-library/src/main/java/org/koin/sample/androidx/data/DataConsumer.kt
@@ -1,0 +1,6 @@
+package org.koin.sample.androidx.data
+
+import org.koin.core.annotation.Factory
+
+@Factory
+class DataConsumer

--- a/examples/android-library/src/main/java/org/koin/sample/androidx/data/DataConsumer.kt
+++ b/examples/android-library/src/main/java/org/koin/sample/androidx/data/DataConsumer.kt
@@ -4,3 +4,8 @@ import org.koin.core.annotation.Factory
 
 @Factory
 class DataConsumer
+
+class MyDataConsumer(val dc : DataConsumer)
+
+@Factory
+fun funDataConsumer(dc : DataConsumer) = MyDataConsumer(dc)

--- a/examples/coffee-maker-module/src/main/kotlin/org/koin/example/coffee/DetachedComponents.kt
+++ b/examples/coffee-maker-module/src/main/kotlin/org/koin/example/coffee/DetachedComponents.kt
@@ -1,0 +1,6 @@
+package org.koin.example.coffee
+
+import org.koin.core.annotation.Single
+
+@Single
+class MyDetachCoffeeComponent

--- a/examples/coffee-maker/build.gradle.kts
+++ b/examples/coffee-maker/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation(project(":coffee-maker-module"))
 
     testImplementation(libs.koin.test)
+    testImplementation(libs.junit)
 }
 
 ksp {

--- a/examples/coffee-maker/src/test/java/CoffeeAppTest.kt
+++ b/examples/coffee-maker/src/test/java/CoffeeAppTest.kt
@@ -7,6 +7,7 @@ import org.koin.core.qualifier.StringQualifier
 import org.koin.core.qualifier.named
 import org.koin.example.CoffeeApp
 import org.koin.example.coffee.CoffeePumpList
+import org.koin.example.coffee.MyDetachCoffeeComponent
 import org.koin.example.coffee.pump.PumpCounter
 import org.koin.example.di.CoffeeAppModule
 import org.koin.example.di.CoffeeTesterModule
@@ -80,6 +81,8 @@ class CoffeeAppTest {
 
         assert(koin.get<CoffeePumpList>().list.size == 2)
         assert(koin.get<PumpCounter>().count == 2)
+
+        assert(koin.getOrNull<MyDetachCoffeeComponent>() != null)
 
         stopKoin()
     }

--- a/projects/koin-annotations/src/commonMain/kotlin/org/koin/core/annotation/CoreAnnotations.kt
+++ b/projects/koin-annotations/src/commonMain/kotlin/org/koin/core/annotation/CoreAnnotations.kt
@@ -195,3 +195,11 @@ annotation class Module(val includes: Array<KClass<*>> = [], val createdAtStart:
  */
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FIELD)
 annotation class ComponentScan(val value: String = "")
+
+/**
+ *
+ *
+ * @param value: package of declared definition
+ */
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FIELD, AnnotationTarget.FUNCTION)
+annotation class Definition(val value: String = "")

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
@@ -17,7 +17,7 @@ package org.koin.compiler
 
 import com.google.devtools.ksp.processing.*
 import com.google.devtools.ksp.symbol.KSAnnotated
-import org.koin.compiler.KspOptions.KOIN_CONFIG_CHECK
+import org.koin.compiler.KspOptions.*
 import org.koin.compiler.generator.KoinGenerator
 import org.koin.compiler.metadata.KoinMetaData
 import org.koin.compiler.scanner.KoinMetaDataScanner
@@ -36,7 +36,6 @@ class BuilderProcessor(
     override fun process(resolver: Resolver): List<KSAnnotated> {
         logger.logging("Scanning symbols ...")
 
-        //TODO Handle allowDefaultModule option
 
         val invalidSymbols = koinMetaDataScanner.scanSymbols(resolver)
         if (invalidSymbols.isNotEmpty()) {
@@ -53,17 +52,8 @@ class BuilderProcessor(
         logger.logging("Scan metadata ...")
         val moduleList = koinMetaDataScanner.scanKoinModules(defaultModule)
 
-        if (isDefaultModuleDisabled()){
-            if (defaultModule.definitions.isNotEmpty()){
-                logger.error("Default module is disabled!")
-                defaultModule.definitions.forEach { def ->
-                    logger.error("definition '${def.packageName}.${def.label}' needs to be defined in a module")
-                }
-            }
-        }
-
         logger.logging("Generate code ...")
-        koinCodeGenerator.generateModules(moduleList, defaultModule)
+        koinCodeGenerator.generateModules(moduleList, defaultModule, isDefaultModuleActive())
 
         if (isConfigCheckActive()) {
             logger.warn("[Experimental] Koin Configuration Check")
@@ -74,11 +64,12 @@ class BuilderProcessor(
     }
 
     private fun isConfigCheckActive(): Boolean {
-        return options[KOIN_CONFIG_CHECK.name] == true.toString()
+        return options.getOrDefault(KOIN_CONFIG_CHECK.name, "true") == true.toString()
     }
 
-    private fun isDefaultModuleDisabled(): Boolean {
-        return options[KspOptions.KOIN_DEFAULT_MODULE.name] == false.toString()
+    //TODO turn KOIN_DEFAULT_MODULE to false by default - Next Major version (breaking)
+    private fun isDefaultModuleActive(): Boolean {
+        return options.getOrDefault(KOIN_DEFAULT_MODULE.name, "true") == true.toString()
     }
 }
 

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/DefinitionGenerationExt.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/DefinitionGenerationExt.kt
@@ -65,7 +65,7 @@ private fun OutputStream.writeExternalDefinitionFunction(
     ctor: String,
     binds: String
 ) {
-    appendText("@Definition(\"${def.packageName}\")\n")
+    appendText("\n@Definition(\"${def.packageName}\")\n")
     appendText("fun Module.$DEFINE_PREFIX${def.label}() = ${def.keyword.keyword}($qualifier$createAtStart) { ${param}${label()}$ctor } $binds")
 }
 

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/ModuleGenerationExt.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/ModuleGenerationExt.kt
@@ -151,7 +151,7 @@ fun OutputStream.generateDefaultModuleHeader(definitions: List<KoinMetaData.Defi
 }
 
 fun OutputStream.generateDefaultModuleFunction() {
-    appendText("\n")
+    appendText("\n\n")
     appendText(DEFAULT_MODULE_FUNCTION)
 }
 

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/Templates.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/Templates.kt
@@ -20,6 +20,7 @@ val DEFAULT_MODULE_HEADER = """
     
         import org.koin.core.KoinApplication
         import org.koin.core.module.Module
+        import org.koin.core.annotation.Definition
         import org.koin.dsl.*
         
     """.trimIndent()

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinMetaData.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinMetaData.kt
@@ -26,6 +26,7 @@ sealed class KoinMetaData {
         val packageName: String,
         val name: String,
         val definitions: MutableList<Definition> = mutableListOf(),
+        val externalDefinitions: MutableList<ExternalDefinition> = mutableListOf(),
         val type: ModuleType = ModuleType.FIELD,
         val componentScan: ComponentScan? = null,
         val includes: List<KSDeclaration>? = null,
@@ -52,6 +53,14 @@ sealed class KoinMetaData {
                 componentScan.packageName.isEmpty() -> defPackageName.contains(packageName, ignoreCase = true)
                 else -> false
             }
+        }
+
+        fun getDefinitionsAsExternals(): List<ExternalDefinition> {
+            return definitions.map { ExternalDefinition(it.packageName, "$DEFINE_PREFIX${it.label}") }
+        }
+
+        companion object {
+            const val DEFINE_PREFIX = "define"
         }
     }
 
@@ -97,6 +106,8 @@ sealed class KoinMetaData {
             }
         }
     }
+
+    data class ExternalDefinition(val targetPackage: String,val name: String)
 
     sealed class Definition(
         val label: String,


### PR DESCRIPTION
Generate definitions as external if not captured in a local module, to be scanned by an external module later.

Those external definitions are functions, that can be called in other modules. They are generated in Default file, where it can be imported via @Definition annotation. 

Examples apps are updated with such use. Like:

```kotlin
package org.koin.sample.androidx.data

@Factory
class DataConsumer
```

will be scanned by in another Gradle module:
```kotlin
@ComponentScan("org.koin.sample.androidx.data")
class DataModule
```

Generated code in Default file, to be scanner by compiler:

```kotlin
@Definition("org.koin.sample.androidx.data")
fun Module.defineDataConsumer() = factory() { org.koin.sample.androidx.data.DataConsumer() } 
```
