### PR TITLE
USE_COMPOSE_VIEWMODEL  arg to generate Viewmodel for compose (Compose DSL API)

### DIFF
--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
@@ -29,7 +29,7 @@ class BuilderProcessor(
     private val options: Map<String, String>
 ) : SymbolProcessor {
 
-    private val koinCodeGenerator = KoinGenerator(codeGenerator, logger)
+    private val koinCodeGenerator = KoinGenerator(codeGenerator, logger, isComposeViewModelActive())
     private val koinMetaDataScanner = KoinMetaDataScanner(logger)
     private val koinConfigVerification = KoinConfigVerification(codeGenerator, logger)
 
@@ -65,6 +65,12 @@ class BuilderProcessor(
 
     private fun isConfigCheckActive(): Boolean {
         return options.getOrDefault(KOIN_CONFIG_CHECK.name, "true") == true.toString()
+    }
+
+    //TODO Use Koin 4.0 ViewModel DSL
+    private fun isComposeViewModelActive(): Boolean {
+        logger.warn("Use Compose ViewModel for @KoinViewModel generation")
+        return options.getOrDefault(USE_COMPOSE_VIEWMODEL.name, "true") == true.toString()
     }
 
     //TODO turn KOIN_DEFAULT_MODULE to false by default - Next Major version (breaking)

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
@@ -64,13 +64,13 @@ class BuilderProcessor(
     }
 
     private fun isConfigCheckActive(): Boolean {
-        return options.getOrDefault(KOIN_CONFIG_CHECK.name, "true") == true.toString()
+        return options.getOrDefault(KOIN_CONFIG_CHECK.name, "false") == true.toString()
     }
 
     //TODO Use Koin 4.0 ViewModel DSL
     private fun isComposeViewModelActive(): Boolean {
         logger.warn("Use Compose ViewModel for @KoinViewModel generation")
-        return options.getOrDefault(USE_COMPOSE_VIEWMODEL.name, "true") == true.toString()
+        return options.getOrDefault(USE_COMPOSE_VIEWMODEL.name, "false") == true.toString()
     }
 
     //TODO turn KOIN_DEFAULT_MODULE to false by default - Next Major version (breaking)

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/KspOptions.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/KspOptions.kt
@@ -17,5 +17,8 @@ package org.koin.compiler
 
 enum class KspOptions {
     KOIN_CONFIG_CHECK,
-    KOIN_DEFAULT_MODULE
+    KOIN_DEFAULT_MODULE,
+
+    //TODO Remove isComposeViewModelActive with Koin 4
+    USE_COMPOSE_VIEWMODEL
 }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/KoinGenerator.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/KoinGenerator.kt
@@ -29,7 +29,8 @@ import java.io.OutputStream
 
 class KoinGenerator(
     val codeGenerator: CodeGenerator,
-    val logger: KSPLogger
+    val logger: KSPLogger,
+    val isComposeViewModelActive: Boolean
 ) {
 
     init {
@@ -80,7 +81,8 @@ class KoinGenerator(
         logger.logging("generate $module - ${module.type}")
         // generate class module
         val moduleFile = codeGenerator.getFile(fileName = module.generateModuleFileName())
-        generateClassModule(moduleFile, module)
+        //TODO Remove isComposeViewModelActive with Koin 4
+        generateClassModule(moduleFile, module, isComposeViewModelActive)
     }
 
     private fun KoinMetaData.Module.generateModuleFileName(): String {

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/AnnotationMetadata.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/AnnotationMetadata.kt
@@ -39,6 +39,10 @@ val FACTORY = DefinitionAnnotation("factory", annotationType = Factory::class)
 val SCOPE = DefinitionAnnotation("scoped", annotationType = Scope::class)
 val SCOPED = DefinitionAnnotation("scoped", annotationType = Scoped::class)
 val KOIN_VIEWMODEL = DefinitionAnnotation("viewModel", "org.koin.androidx.viewmodel.dsl.viewModel", KoinViewModel::class)
+
+//TODO Remove isComposeViewModelActive with Koin 4
+val KOIN_VIEWMODEL_COMPOSE = DefinitionAnnotation("viewModel", "org.koin.compose.viewmodel.dsl.viewModel", KoinViewModel::class)
+
 val KOIN_WORKER = DefinitionAnnotation("worker", "org.koin.androidx.workmanager.dsl.worker", KoinWorker::class)
 
 val DEFINITION_ANNOTATION_LIST = listOf(SINGLE, SINGLETON,FACTORY, SCOPE, SCOPED,KOIN_VIEWMODEL, KOIN_WORKER)


### PR DESCRIPTION
Allow to generate Compose KMP ViewModel definition instead of default Android.

For this, we need a temporary argument, while Koin 4 will bring a common ViewModel DSL for that.

```kotlin
ksp {
    arg("USE_COMPOSE_VIEWMODEL","true")
}
```