### PR TITLE
Config check for ignored types, nullable and provided type

### DIFF
--- a/examples/android-coffee-maker/build.gradle.kts
+++ b/examples/android-coffee-maker/build.gradle.kts
@@ -48,5 +48,5 @@ dependencies {
 
 ksp {
     arg("KOIN_CONFIG_CHECK","true")
-//    arg("KOIN_DEFAULT_MODULE","false")
+    arg("KOIN_DEFAULT_MODULE","false")
 }

--- a/examples/android-coffee-maker/src/main/java/org/koin/sample/androidx/MainActivity.kt
+++ b/examples/android-coffee-maker/src/main/java/org/koin/sample/androidx/MainActivity.kt
@@ -29,7 +29,7 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-//        getKoin().declare(ProvidedComponent())
+        getKoin().declare(MyProvidedComponent())
 
         setContentView(R.layout.main_activity)
         title = "Android Coffee Maker"

--- a/examples/android-coffee-maker/src/main/java/org/koin/sample/androidx/MainActivity.kt
+++ b/examples/android-coffee-maker/src/main/java/org/koin/sample/androidx/MainActivity.kt
@@ -11,6 +11,7 @@ import org.koin.core.parameter.parametersOf
 import org.koin.core.qualifier.named
 import org.koin.sample.android.library.MyScope
 import org.koin.sample.androidx.app.*
+import org.koin.sample.androidx.data.ProvidedComponent
 import org.koin.sample.androidx.data.TaskDatasource
 
 class MainActivity : AppCompatActivity() {
@@ -27,6 +28,8 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+//        getKoin().declare(ProvidedComponent())
 
         setContentView(R.layout.main_activity)
         title = "Android Coffee Maker"

--- a/examples/android-coffee-maker/src/main/java/org/koin/sample/androidx/app/MyPresenter.kt
+++ b/examples/android-coffee-maker/src/main/java/org/koin/sample/androidx/app/MyPresenter.kt
@@ -7,5 +7,7 @@ import org.koin.core.annotation.Provided
 import org.koin.sample.androidx.MainActivity
 import org.koin.sample.androidx.data.ProvidedComponent
 
+class MyProvidedComponent
+
 @Factory
-class MyPresenter(@InjectedParam val mainActivity: MainActivity, val context: Context)
+class MyPresenter(@InjectedParam val mainActivity: MainActivity, val context: Context, @Provided val provided : MyProvidedComponent)

--- a/examples/android-coffee-maker/src/main/java/org/koin/sample/androidx/app/MyPresenter.kt
+++ b/examples/android-coffee-maker/src/main/java/org/koin/sample/androidx/app/MyPresenter.kt
@@ -3,7 +3,9 @@ package org.koin.sample.androidx.app
 import android.content.Context
 import org.koin.core.annotation.Factory
 import org.koin.core.annotation.InjectedParam
+import org.koin.core.annotation.Provided
 import org.koin.sample.androidx.MainActivity
+import org.koin.sample.androidx.data.ProvidedComponent
 
 @Factory
-class MyPresenter(@InjectedParam val mainActivity: MainActivity, @InjectedParam val context: Context)
+class MyPresenter(@InjectedParam val mainActivity: MainActivity, val context: Context)

--- a/examples/android-coffee-maker/src/main/java/org/koin/sample/androidx/data/ProvidedComponent.kt
+++ b/examples/android-coffee-maker/src/main/java/org/koin/sample/androidx/data/ProvidedComponent.kt
@@ -1,0 +1,3 @@
+package org.koin.sample.androidx.data
+
+class ProvidedComponent

--- a/examples/android-coffee-maker/src/test/java/AndroidModuleTest.kt
+++ b/examples/android-coffee-maker/src/test/java/AndroidModuleTest.kt
@@ -1,14 +1,17 @@
 package org.koin.sample.androidx
 
 import org.junit.Test
+import org.koin.android.ext.android.getKoin
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.ksp.generated.module
 import org.koin.sample.android.library.CommonRepository
 import org.koin.sample.android.library.MyScope
+import org.koin.sample.androidx.app.MyPresenter
 import org.koin.sample.androidx.app.ScopedStuff
 import org.koin.sample.androidx.data.DataConsumer
 import org.koin.sample.androidx.data.MyDataConsumer
+import org.koin.sample.androidx.data.ProvidedComponent
 import org.koin.sample.androidx.di.AppModule
 import org.koin.sample.androidx.di.DataModule
 import org.koin.sample.androidx.repository.RepositoryModule

--- a/examples/android-library/build.gradle.kts
+++ b/examples/android-library/build.gradle.kts
@@ -35,5 +35,5 @@ dependencies {
 
 ksp {
     arg("KOIN_CONFIG_CHECK","true")
-//    arg("KOIN_DEFAULT_MODULE","false")
+    arg("KOIN_DEFAULT_MODULE","false")
 }

--- a/projects/koin-annotations/src/commonMain/kotlin/org/koin/android/annotation/AndroidAnnotations.kt
+++ b/projects/koin-annotations/src/commonMain/kotlin/org/koin/android/annotation/AndroidAnnotations.kt
@@ -17,7 +17,6 @@ package org.koin.android.annotation
 
 import kotlin.reflect.KClass
 
-//TODO Seperate Android annotations, to have minimum requirement deps as Android
 
 /**
  * ViewModel annotation for Koin definition
@@ -37,6 +36,7 @@ import kotlin.reflect.KClass
 @Target(AnnotationTarget.CLASS,AnnotationTarget.FUNCTION)
 annotation class KoinViewModel(val binds: Array<KClass<*>> = [])
 
+//TODO Separate Android annotations, to have minimum requirement deps as Android
 /**
  * Worker annotation for Koin Definition
  * Declare type as `worker` definition

--- a/projects/koin-annotations/src/commonMain/kotlin/org/koin/core/annotation/CoreAnnotations.kt
+++ b/projects/koin-annotations/src/commonMain/kotlin/org/koin/core/annotation/CoreAnnotations.kt
@@ -197,7 +197,13 @@ annotation class Module(val includes: Array<KClass<*>> = [], val createdAtStart:
 annotation class ComponentScan(val value: String = "")
 
 /**
- *
+ * Tag a dependency as already provided by Koin (like DSL declaration, or internals)
+ */
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER)
+annotation class Provided
+
+/**
+ * Internal usage for components discovery in generated package
  *
  * @param value: package of declared definition
  */

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
@@ -56,7 +56,7 @@ class BuilderProcessor(
         koinCodeGenerator.generateModules(moduleList, defaultModule, isDefaultModuleActive())
 
         if (isConfigCheckActive()) {
-            logger.warn("[Experimental] Koin Configuration Check")
+            logger.warn("Koin Configuration Check")
             koinConfigVerification.verifyDefinitionDeclarations(moduleList + defaultModule, resolver)
             koinConfigVerification.verifyModuleIncludes(moduleList + defaultModule, resolver)
         }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/KoinGenerator.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/KoinGenerator.kt
@@ -55,7 +55,7 @@ class KoinGenerator(
         generateDefaultModule: Boolean
     ) {
         logger.logging("generate default file ...")
-        val defaultModuleFile = codeGenerator.getFile(fileName = "Default")
+        val defaultModuleFile = codeGenerator.getFile(fileName = "Default${defaultModule.hashCode()}")
         defaultModuleFile.generateDefaultModuleHeader(defaultModule.definitions)
         generateAllExternalDefinitions(defaultModule, defaultModuleFile)
 

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinMetaData.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinMetaData.kt
@@ -193,6 +193,7 @@ sealed class KoinMetaData {
             val isNullable: Boolean = false,
             val scopeId: String? = null,
             override val hasDefault: Boolean,
+            val alreadyProvided : Boolean = false,
             val type: KSType, val kind: DependencyKind = DependencyKind.Single
         ) : DefinitionParameter(isNullable)
 

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/KspExt.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/KspExt.kt
@@ -126,7 +126,8 @@ private fun getParameter(param: KSValueParameter): KoinMetaData.DefinitionParame
                 isLazy -> KoinMetaData.DependencyKind.Lazy
                 else -> KoinMetaData.DependencyKind.Single
             }
-            KoinMetaData.DefinitionParameter.Dependency(name = paramName, hasDefault = hasDefault, kind = kind,  isNullable = isNullable, type = resolvedType)
+            val provided = (annotationName == "${Provided::class.simpleName}")
+            KoinMetaData.DefinitionParameter.Dependency(name = paramName, hasDefault = hasDefault, kind = kind,  isNullable = isNullable, type = resolvedType, alreadyProvided = provided)
         }
     }
 }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/Ignored.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/Ignored.kt
@@ -1,0 +1,12 @@
+package org.koin.compiler.verify
+
+
+internal val ignored = listOf(
+    "kotlin.Any",
+    "android.content.Context",
+    "android.app.Application",
+    "androidx.appcompat.app.AppCompatActivity",
+    "androidx.appcompat.app.AppCompatActivity",
+    "androidx.fragment.app.Fragment",
+    "androidx.lifecycle.SavedStateHandle"
+)


### PR DESCRIPTION
Fix configuration check about ignored type list (Android) or if the type nullable.

Introduce `@Provided` to let define a dependency as provided externally to Koin annotations config. Like if you have a type declared manually in DSL ou on the fly, you can unlock Koin config check to verify it.

example:
```kotlin
@Factory
class MyPresenter(val context: Context, @Provided val provided : MyProvidedComponent)
```

Context: is detected as ignored type to verify
MyProvidedComponent: is tagged as provided externally

 