### PR TITLE
Property value to define value for Property in code

### DIFF
--- a/examples/other-ksp/src/main/kotlin/org/koin/example/newmodule/ComponentWithDefaultValues.kt
+++ b/examples/other-ksp/src/main/kotlin/org/koin/example/newmodule/ComponentWithDefaultValues.kt
@@ -2,7 +2,9 @@ package org.koin.example.newmodule
 
 import org.koin.core.annotation.Factory
 import org.koin.core.annotation.Property
+import org.koin.core.annotation.PropertyValue
 import org.koin.core.annotation.Single
+import org.koin.example.newmodule.ComponentWithProps.Companion.DEFAULT_ID
 
 public interface ComponentInterface {
 
@@ -16,9 +18,10 @@ public class ComponentWithDefaultValues(
 
 @Factory
 public class ComponentWithProps(
-    @Property("id") public val id : String = DEFAULT_ID
+    @Property("id") public val id : String
 ){
     public companion object {
+        @PropertyValue("id")
         public const val DEFAULT_ID : String = "_empty_id"
     }
 }

--- a/examples/other-ksp/src/test/kotlin/org.koin.example/TestModule.kt
+++ b/examples/other-ksp/src/test/kotlin/org.koin.example/TestModule.kt
@@ -11,6 +11,7 @@ import org.koin.example.animal.Cat
 import org.koin.example.animal.Dog
 import org.koin.example.`interface`.MyInterfaceExt
 import org.koin.example.newmodule.*
+import org.koin.example.newmodule.ComponentWithProps.Companion.DEFAULT_ID
 import org.koin.example.newmodule.mymodule.MyModule3
 import org.koin.example.newmodule.mymodule.MyOtherComponent3
 import org.koin.example.scope.MyScopeFactory
@@ -44,6 +45,9 @@ class TestModule {
         koin.get<MyOtherComponent3F>()
 
         //TODO Handle default prop
+        koin.get<ComponentWithProps>().let {
+            assertTrue { it.id == DEFAULT_ID }
+        }
         koin.setProperty("id", "new_id")
         koin.get<ComponentWithProps>().let {
             assertTrue { it.id == "new_id" }

--- a/projects/koin-annotations/src/commonMain/kotlin/org/koin/core/annotation/CoreAnnotations.kt
+++ b/projects/koin-annotations/src/commonMain/kotlin/org/koin/core/annotation/CoreAnnotations.kt
@@ -162,6 +162,20 @@ annotation class InjectedParam
 annotation class Property(val value: String)
 
 /**
+ * Annotate a field value that will be Property default value
+ *
+ * @PropertyValue("name")
+ * val defaultName = "MyName"
+ *
+ * @Factory
+ * class MyClass(@Property("name") val name : String)
+ *
+ * will result in `factory { MyClass(getProperty("name", defaultName)) }`
+ */
+@Target(AnnotationTarget.FIELD)
+annotation class PropertyValue(val value: String)
+
+/**
  * Class annotation, to help gather definitions inside a Koin module.
  * Each function can be annotated with a Koin definition annotation, to declare it
  *

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/DefinitionGenerationExt.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/DefinitionGenerationExt.kt
@@ -197,7 +197,10 @@ private fun generateConstructor(constructorParameters: List<KoinMetaData.Definit
             }
 
             is KoinMetaData.DefinitionParameter.ParameterInject -> if (!isNullable) "params.get()" else "params.getOrNull()"
-            is KoinMetaData.DefinitionParameter.Property -> if (!isNullable) "getProperty(\"${ctorParam.value}\")" else "getPropertyOrNull(\"${ctorParam.value}\")"
+            is KoinMetaData.DefinitionParameter.Property -> {
+                val defaultValue = if (ctorParam.defaultField != null) ",${ctorParam.defaultField}" else ""
+                if (!isNullable) "getProperty(\"${ctorParam.value}\"$defaultValue)" else "getPropertyOrNull(\"${ctorParam.value}\",$defaultValue)"
+            }
         }
     }
 }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinMetaData.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinMetaData.kt
@@ -107,6 +107,8 @@ sealed class KoinMetaData {
         }
     }
 
+    data class PropertyValue(val id : String, val field : String)
+
     data class ExternalDefinition(val targetPackage: String,val name: String)
 
     sealed class Definition(
@@ -207,6 +209,7 @@ sealed class KoinMetaData {
             override val name: String?,
             val value: String? = null,
             val isNullable: Boolean = false,
+            var defaultField: String? = null,
             override val hasDefault: Boolean
         ) : DefinitionParameter(isNullable)
     }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/KspExt.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/KspExt.kt
@@ -106,7 +106,7 @@ private fun getParameter(param: KSValueParameter): KoinMetaData.DefinitionParame
 
     return when (annotationName) {
         "${InjectedParam::class.simpleName}" -> KoinMetaData.DefinitionParameter.ParameterInject(name = paramName, isNullable = isNullable, hasDefault = hasDefault)
-        "${Property::class.simpleName}" -> KoinMetaData.DefinitionParameter.Property(name = paramName, value = annotationValue, isNullable, hasDefault)
+        "${Property::class.simpleName}" -> KoinMetaData.DefinitionParameter.Property(name = paramName, value = annotationValue, isNullable, hasDefault = hasDefault)
         "${Named::class.simpleName}" -> {
             val qualifier = firstAnnotation.arguments.getNamed().getValue()
             KoinMetaData.DefinitionParameter.Dependency(name = paramName, qualifier = qualifier, isNullable = isNullable, hasDefault = hasDefault, type = resolvedType)


### PR DESCRIPTION
Koin Annotations offers you the possibility to define a default value for a property, directly from your code with `@PropertyValue` annotation.
Let's follow our sample:

```kotlin
@Factory
public class ComponentWithProps(
    @Property("id") public val id : String
){
    public companion object {
        @PropertyValue("id")
        public const val DEFAULT_ID : String = "_empty_id"
    }
}
```

The generated DSL equivalent will be `factory { ComponentWithProps(getProperty("id", ComponentWithProps.DEFAULT_ID)) }`

Fix #73 