### PR TITLE
fix: Removed "it" from forbiddenKeywords and replace "" with "_ -> " …

### DIFF
--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/DefinitionWriter.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/DefinitionWriter.kt
@@ -95,7 +95,7 @@ class DefinitionWriter(
     }
 
     private fun List<KoinMetaData.DefinitionParameter>.generateParamFunction(): String {
-        return if (any { it is KoinMetaData.DefinitionParameter.ParameterInject }) "params -> " else ""
+        return if (any { it is KoinMetaData.DefinitionParameter.ParameterInject }) "params -> " else "_ -> "
     }
 
     private fun String?.generateQualifier(): String = when {

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/ext/KspExt.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/ext/KspExt.kt
@@ -138,7 +138,7 @@ internal fun List<KSValueArgument>.getValueArgument(): String? {
 
 fun KSClassDeclaration.getPackageName() : String = packageName.asString()
 
-val forbiddenKeywords = listOf("interface","it")
+val forbiddenKeywords = listOf("interface")
 fun String.filterForbiddenKeywords() : String{
     return split(".").joinToString(".") {
         if (it in forbiddenKeywords) "`$it`" else it


### PR DESCRIPTION
Adding back ticks  to "it" causes problems when ksp tries to generate variable names when package names start with "it", hence the removal from `forbiddenKeywords`.

We ([samuelepozzebon](https://github.com/samuelepozzebon) and I) also changed `""` to `"_ -> "` in order to fix the issue "it" creates since it is used as the default param name.

For example:
`single() {  'it'.example.italy.classProvider() }...`
become
`single() { _ -> it.example.italy.classProvider() }...`



This PR fixes: https://github.com/InsertKoinIO/koin-annotations/issues/161