### PR TITLE
Fix compose import

### DIFF
--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/AnnotationMetadata.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/AnnotationMetadata.kt
@@ -40,7 +40,7 @@ val SCOPED = DefinitionAnnotation("scoped", annotationType = Scoped::class)
 val KOIN_VIEWMODEL = DefinitionAnnotation("viewModel", "org.koin.androidx.viewmodel.dsl.viewModel", KoinViewModel::class)
 
 //TODO Remove isComposeViewModelActive with Koin 4
-val KOIN_VIEWMODEL_COMPOSE = DefinitionAnnotation("viewModel", "org.koin.compose.viewmodel.dsl.viewModel", KoinViewModel::class)
+val KOIN_VIEWMODEL_COMPOSE = DefinitionAnnotation("viewModel", "org.koin.core.module.dsl.viewModel", KoinViewModel::class)
 
 val KOIN_WORKER = DefinitionAnnotation("worker", "org.koin.androidx.workmanager.dsl.worker", KoinWorker::class)
 


### PR DESCRIPTION
Hey @arnaudgiuliani , the import generated when `KOIN_USE_COMPOSE_VIEWMODEL` is active is `org.koin.compose.viewmodel.dsl.viewModel` which is unresolved and throws an error `Unresolved reference 'viewmodel'.` 

.Also from the warning when the above argument is inactive says the import should be from `org.koin.core.module.dsl.*`
```
@Deprecated("Moved ViewModel DSL package. Remove old imports and use org.koin.core.module.dsl.*
```

Potential fix for #171 