### PR TITLE
feat: allow creating custom qualifier annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![logo](https://github.com/InsertKoinIO/koin/blob/main/docs/img/koin_main_logo.png)
 
-[![Kotlin](https://img.shields.io/badge/Kotlin-1.8.10-blue.svg?style=flat&logo=kotlin)](https://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.0.20-blue.svg?style=flat&logo=kotlin)](https://kotlinlang.org)
 [![Apache 2 License](https://img.shields.io/github/license/InsertKoinIO/koin)](https://github.com/InsertKoinIO/koin/blob/main/LICENSE.txt)
 [![Slack channel](https://img.shields.io/badge/Chat-Slack-orange.svg?style=flat&logo=slack)](https://kotlinlang.slack.com/messages/koin/)
 

--- a/docs/reference/koin-annotations/definitions.md
+++ b/docs/reference/koin-annotations/definitions.md
@@ -90,6 +90,28 @@ When resolving a dependency, just use the qualifier with `named` function:
 val logger: LoggerDataSource by inject(named("InMemoryLogger"))
 ```
 
+It is also possible to create custom qualifier annotations. Using the previous example:
+
+```kotlin
+@Named
+annotation class InMemoryLogger
+
+@Named
+annotation class DatabaseLogger
+
+@Single
+@InMemoryLogger
+class LoggerInMemoryDataSource : LoggerDataSource
+
+@Single
+@DatabaseLogger
+class LoggerLocalDataSource(private val logDao: LogDao) : LoggerDataSource
+```
+
+```kotlin
+val logger: LoggerDataSource by inject(named<InMemoryLogger>())
+```
+
 ## Injected Parameters with @InjectedParam
 
 You can tag a constructor member as "injected parameter", which means that the dependency will be passed in the graph when calling for resolution.

--- a/examples/other-ksp/src/main/kotlin/org/koin/example/animal/Animal.kt
+++ b/examples/other-ksp/src/main/kotlin/org/koin/example/animal/Animal.kt
@@ -1,9 +1,6 @@
 package org.koin.example.animal
 
-import org.koin.core.annotation.ComponentScan
-import org.koin.core.annotation.Factory
-import org.koin.core.annotation.Module
-import org.koin.core.annotation.Single
+import org.koin.core.annotation.*
 import kotlin.random.Random
 
 public interface Animal
@@ -14,12 +11,28 @@ public class Dog : Animal
 @Single(binds = [])
 public class Cat : Animal
 
+public class Bunny(public val color: String) : Animal
+
+@Named
+public annotation class WhiteBunny
+
+@Qualifier
+public annotation class BlackBunny
+
 @Module
 @ComponentScan
 public class AnimalModule {
 
     @Factory
     public fun animal(cat: Cat, dog: Dog): Animal = if (randomBoolean()) cat else dog
+
+    @Single
+    @WhiteBunny
+    public fun whiteBunny(): Bunny = Bunny("White")
+
+    @Single
+    @BlackBunny
+    public fun blackBunny(): Bunny = Bunny("Black")
 
     private fun randomBoolean(): Boolean = Random.nextBoolean()
 }

--- a/examples/other-ksp/src/test/kotlin/org.koin.example/TestModule.kt
+++ b/examples/other-ksp/src/test/kotlin/org.koin.example/TestModule.kt
@@ -2,13 +2,12 @@ package org.koin.example
 
 import org.junit.Test
 import org.koin.core.Koin
+import org.koin.core.error.NoDefinitionFoundException
 import org.koin.core.logger.Level
 import org.koin.core.qualifier.named
+import org.koin.core.qualifier.qualifier
 import org.koin.dsl.koinApplication
-import org.koin.example.animal.Animal
-import org.koin.example.animal.AnimalModule
-import org.koin.example.animal.Cat
-import org.koin.example.animal.Dog
+import org.koin.example.animal.*
 import org.koin.example.`interface`.MyInterfaceExt
 import org.koin.example.newmodule.*
 import org.koin.example.newmodule.ComponentWithProps.Companion.DEFAULT_ID
@@ -19,6 +18,8 @@ import org.koin.example.scope.MyScopedInstance
 import org.koin.example.scope.ScopeModule
 import org.koin.ksp.generated.defaultModule
 import org.koin.ksp.generated.module
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class TestModule {
@@ -65,6 +66,12 @@ class TestModule {
         assertTrue {
             koin.get<MyScopeFactory>().msi == koin.get<MyScopeFactory>().msi
         }
+
+        assertFailsWith(NoDefinitionFoundException::class) {
+            koin.get<Bunny>()
+        }
+
+        assertEquals("White", koin.get<Bunny>(qualifier<WhiteBunny>()).color)
     }
 
     private fun randomGetAnimal(koin: Koin): Animal {

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/ext/KspExt.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/ext/KspExt.kt
@@ -73,16 +73,20 @@ fun List<KSValueArgument>.getQualifier(): KoinMetaData.Qualifier {
             ?: error("Qualifier annotation needs parameters: either type value or name")
 }
 
+private val qualifierAnnotations = listOf("Named", "Qualifier")
 fun KSAnnotated.getQualifier(): String? {
     val qualifierAnnotation = annotations.firstOrNull { a ->
         val annotationName = a.shortName.asString()
-        (annotationName == "Named" || annotationName == "Qualifier")
+        if (annotationName in qualifierAnnotations) true
+        else (a.annotationType.resolve().declaration as KSClassDeclaration).annotations.any { a2 ->
+            a2.shortName.asString() in qualifierAnnotations
+        }
     }
     return qualifierAnnotation?.let {
         when(it.shortName.asString()){
             "${Named::class.simpleName}" -> it.arguments.getNamed().getValue()
             "${Qualifier::class.simpleName}" -> it.arguments.getQualifier().getValue()
-            else -> null
+            else -> it.annotationType.resolve().declaration.qualifiedName?.asString()
         }
     }
 }


### PR DESCRIPTION
Following #108, I was wondering if it was possible to improve class-based qualifiers even more by being able to make our own qualifier annotations like so:

```kotlin
@Named
annotation class InMemoryLogger

@Named
annotation class DatabaseLogger

@Single
@InMemoryLogger
class LoggerInMemoryDataSource : LoggerDataSource

@Single
@DatabaseLogger
class LoggerLocalDataSource(private val logDao: LogDao) : LoggerDataSource
```

These dependencies would be injected that way:

```kotlin
val logger: LoggerDataSource by inject(named<InMemoryLogger>())
```

They would also be injected into constructors using the same annotation.

I think the syntax looks better that way but not everyone may think the same. Regardless, I feel like it wouldn't be a bad idea to give the developer the ability to choose between whatever option they prefer to declare a qualifier.

I don't have a lot of experience with KSP but I've managed to implement the feature (it works with either `@Named` or `@Qualifier`). I have no idea of the impact on compilation speed, but I'd expect that there is at least some impact because in order to find the qualifier for a definition, we need to resolve each of its annotations until we find one whose declaration is annotated with `@Named` or `@Qualifier`.

This could be extended to Scopes as well, I don't personally use them a lot, but I could try to implement the same feature for Scopes.