### PR TITLE
Close OutputStream created by `writeTagFile()`

### DIFF
--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/KoinTagWriter.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/KoinTagWriter.kt
@@ -29,10 +29,10 @@ class KoinTagWriter(val codeGenerator: CodeGenerator, val logger: KSPLogger) {
         if (!isAlreadyGenerated) {
             logger.logging("Koin Tags Generation ...")
             val tagFileName = "KoinMeta-${hashCode()}"
-            val tagFileStream = writeTagFile(tagFileName)
-
-            writeModuleTags(moduleList,tagFileStream)
-            writeDefinitionsTags(allDefinitions,tagFileStream)
+            writeTagFile(tagFileName).use { tagFileStream ->
+                writeModuleTags(moduleList,tagFileStream)
+                writeDefinitionsTags(allDefinitions,tagFileStream)
+            }
         }
     }
 

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/KoinTagWriter.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/KoinTagWriter.kt
@@ -30,8 +30,8 @@ class KoinTagWriter(val codeGenerator: CodeGenerator, val logger: KSPLogger) {
             logger.logging("Koin Tags Generation ...")
             val tagFileName = "KoinMeta-${hashCode()}"
             writeTagFile(tagFileName).use { tagFileStream ->
-                writeModuleTags(moduleList,tagFileStream)
-                writeDefinitionsTags(allDefinitions,tagFileStream)
+                writeModuleTags(moduleList, tagFileStream)
+                writeDefinitionsTags(allDefinitions, tagFileStream)
             }
         }
     }


### PR DESCRIPTION
Thanks for sharing this ksp compiler, it really helps our development. 🤝 

I found that `OutputStream` instances created by `writeTagFile()` are not closed, so here I want to suggest a small fix.
I will create another PR to make this KSP compiler [reproducible](https://reproducible-builds.org/), but first please review this small PR.