### PR TITLE
Realize Reproducible Builds by stabilize name of the `KoinMeta` file

### DIFF
--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/KoinTagWriter.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/KoinTagWriter.kt
@@ -29,10 +29,10 @@ class KoinTagWriter(val codeGenerator: CodeGenerator, val logger: KSPLogger) {
         if (!isAlreadyGenerated) {
             logger.logging("Koin Tags Generation ...")
             val tagFileName = "KoinMeta-${hashCode()}"
-            val tagFileStream = writeTagFile(tagFileName)
-
-            writeModuleTags(moduleList,tagFileStream)
-            writeDefinitionsTags(allDefinitions,tagFileStream)
+            writeTagFile(tagFileName).use { tagFileStream ->
+                writeModuleTags(moduleList,tagFileStream)
+                writeDefinitionsTags(allDefinitions,tagFileStream)
+            }
         }
     }
 

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/KoinTagWriter.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/KoinTagWriter.kt
@@ -34,8 +34,11 @@ class KoinTagWriter(val codeGenerator: CodeGenerator, val logger: KSPLogger) {
     }
 
     /**
-     * To realize reproducible-builds, write everything to a temporal file then copy it to the tag file.
-     * This method lets us compute the digest of tag file and use it to name it.
+     * To realize [reproducible-builds](https://reproducible-builds.org/), write everything to a temporal file
+     * then copy it to the tag file.
+     * By this method, we can compute the digest of tag file and use it to name it.
+     *
+     * @author Kengo TODA
      */
     @OptIn(ExperimentalStdlibApi::class)
     private fun createTagFile(


### PR DESCRIPTION
Current implementation decides the name of `KoinMeta` file randomly, and it makes the build not reproducible. In other words, `kspKotlin` task generates different output even when input is same.

By this behaviour, Gradle tasks depending on the generated `KoinMeta` file like `compileKotlin` are executed even though no code has been changed. I will share screenshot of Gradle build scan for reference:

![image](https://github.com/user-attachments/assets/f152f841-9dfe-4f90-b1bc-8ae129b2e34c)

I want to suggest this change to stabilize name of the `KoinMeta` file. By this change, koin-ksp-compiler will compute digest of generated file, then use it to name the `KoinMeta` file. It will make the `kspKotlin` task reproducible, and make successor tasks able to use build cache.