### PR TITLE
fix: custom qualifier annotations not generating qualifier at injection point

### DIFF
--- a/examples/other-ksp/src/main/kotlin/org/koin/example/animal/Animal.kt
+++ b/examples/other-ksp/src/main/kotlin/org/koin/example/animal/Animal.kt
@@ -13,6 +13,9 @@ public class Cat : Animal
 
 public class Bunny(public val color: String) : Animal
 
+@Single
+public class Farm(@WhiteBunny public val whiteBunny: Bunny, @BlackBunny public val blackBunny: Bunny)
+
 @Named
 public annotation class WhiteBunny
 
@@ -22,7 +25,6 @@ public annotation class BlackBunny
 @Module
 @ComponentScan
 public class AnimalModule {
-
     @Factory
     public fun animal(cat: Cat, dog: Dog): Animal = if (randomBoolean()) cat else dog
 

--- a/examples/other-ksp/src/test/kotlin/org.koin.example/TestModule.kt
+++ b/examples/other-ksp/src/test/kotlin/org.koin.example/TestModule.kt
@@ -72,6 +72,10 @@ class TestModule {
         }
 
         assertEquals("White", koin.get<Bunny>(qualifier<WhiteBunny>()).color)
+
+        val farm = koin.get<Farm>()
+        assertEquals("White", farm.whiteBunny.color)
+        assertEquals("Black", farm.blackBunny.color)
     }
 
     private fun randomGetAnimal(koin: Koin): Animal {

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/ext/KspExt.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/ext/KspExt.kt
@@ -73,14 +73,11 @@ fun List<KSValueArgument>.getQualifier(): KoinMetaData.Qualifier {
             ?: error("Qualifier annotation needs parameters: either type value or name")
 }
 
-private val qualifierAnnotations = listOf("Named", "Qualifier")
+private val qualifierAnnotations = listOf(Named::class.simpleName, Qualifier::class.simpleName)
 fun KSAnnotated.getQualifier(): String? {
     val qualifierAnnotation = annotations.firstOrNull { a ->
         val annotationName = a.shortName.asString()
-        if (annotationName in qualifierAnnotations) true
-        else (a.annotationType.resolve().declaration as KSClassDeclaration).annotations.any { a2 ->
-            a2.shortName.asString() in qualifierAnnotations
-        }
+        annotationName in qualifierAnnotations || a.annotationType.resolve().isCustomQualifierAnnotation()
     }
     return qualifierAnnotation?.let {
         when(it.shortName.asString()){
@@ -127,14 +124,23 @@ private fun getParameter(param: KSValueParameter): KoinMetaData.DefinitionParame
         }
         //TODO type value for ScopeId
         else -> {
-            val kind = when {
-                isList -> KoinMetaData.DependencyKind.List
-                isLazy -> KoinMetaData.DependencyKind.Lazy
-                else -> KoinMetaData.DependencyKind.Single
+            val annotationType = firstAnnotation?.annotationType?.resolve()
+            if (annotationType != null && annotationType.isCustomQualifierAnnotation()) {
+                KoinMetaData.DefinitionParameter.Dependency(name = paramName, qualifier = annotationType.declaration.qualifiedName?.asString(), isNullable = isNullable, hasDefault = hasDefault, type = resolvedType, alreadyProvided = hasProvidedAnnotation(param))
+            } else {
+                val kind = when {
+                    isList -> KoinMetaData.DependencyKind.List
+                    isLazy -> KoinMetaData.DependencyKind.Lazy
+                    else -> KoinMetaData.DependencyKind.Single
+                }
+                KoinMetaData.DefinitionParameter.Dependency(name = paramName, hasDefault = hasDefault, kind = kind, isNullable = isNullable, type = resolvedType, alreadyProvided = hasProvidedAnnotation(param))
             }
-            KoinMetaData.DefinitionParameter.Dependency(name = paramName, hasDefault = hasDefault, kind = kind,  isNullable = isNullable, type = resolvedType, alreadyProvided = hasProvidedAnnotation(param))
         }
     }
+}
+
+private fun KSType.isCustomQualifierAnnotation(): Boolean {
+    return (declaration as KSClassDeclaration).annotations.any { it.shortName.asString() in qualifierAnnotations }
 }
 
 internal fun List<KSValueArgument>.getValueArgument(): String? {


### PR DESCRIPTION
Following #176, after some testing on v2.0.0-Beta3, I found that the custom qualifier annotations do not generate the qualifier when used to inject a parameter, which would in most cases cause a `NoDefinitionFoundException` at runtime.

This PR addresses the issue by correctly generating the corresponding qualifier.

Example:

```kotlin
@Named
public annotation class WhiteBunny

@Qualifier
public annotation class BlackBunny

@Single
public class Farm(@WhiteBunny public val whiteBunny: Bunny, @BlackBunny public val blackBunny: Bunny)
```

Generated code before fix:
```kotlin
single() { _ -> org.koin.example.animal.Farm(whiteBunny=get(),blackBunny=get()) }
```

Generated code after fix:
```
single() { _ -> org.koin.example.animal.Farm(whiteBunny=get(qualifier=org.koin.core.qualifier.StringQualifier("org.koin.example.animal.WhiteBunny")),blackBunny=get(qualifier=org.koin.core.qualifier.StringQualifier("org.koin.example.animal.BlackBunny"))) }
```

This test case has been added to the existing unit test.