### PR TITLE
ViewModel generation default to Koin 4.0

### DIFF
--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
@@ -30,8 +30,8 @@ class BuilderProcessor(
     private val options: Map<String, String>
 ) : SymbolProcessor {
 
-    private val isComposeViewModelActive = isComposeViewModelActive() || isKoinComposeViewModelActive()
-    private val koinCodeGenerator = KoinCodeGenerator(codeGenerator, logger, isComposeViewModelActive)
+    private val isViewModelMPActive = isKoinViewModelMPActive()
+    private val koinCodeGenerator = KoinCodeGenerator(codeGenerator, logger, isViewModelMPActive)
     private val koinMetaDataScanner = KoinMetaDataScanner(logger)
     private val koinTagWriter = KoinTagWriter(codeGenerator, logger)
     private val koinConfigChecker = KoinConfigChecker(codeGenerator, logger)
@@ -84,18 +84,9 @@ class BuilderProcessor(
         return options.getOrDefault(KOIN_CONFIG_CHECK.name, "false") == true.toString()
     }
 
-    //TODO Use Koin 4.0 ViewModel DSL
-    @Deprecated("use isKoinComposeViewModelActive")
-    private fun isComposeViewModelActive(): Boolean {
-        val option = options.getOrDefault(USE_COMPOSE_VIEWMODEL.name, "false") == true.toString()
-        if (option) logger.warn("[Deprecated] 'USE_COMPOSE_VIEWMODEL' arg is deprecated. Please use 'KOIN_USE_COMPOSE_VIEWMODEL'")
-        return option
-    }
-
-    private fun isKoinComposeViewModelActive(): Boolean {
-        val option =
-            options.getOrDefault(KOIN_USE_COMPOSE_VIEWMODEL.name, "false") == true.toString()
-        if (option) logger.warn("Activate Compose ViewModel for @KoinViewModel generation")
+    // Allow to disable usage of ViewModel MP API and
+    private fun isKoinViewModelMPActive(): Boolean {
+        val option = options.getOrDefault(KOIN_USE_COMPOSE_VIEWMODEL.name, "true") == true.toString()
         return option
     }
 
@@ -104,7 +95,6 @@ class BuilderProcessor(
         return options.getOrDefault(KOIN_DEFAULT_MODULE.name, "true") == true.toString()
     }
 }
-
 
 class BuilderProcessorProvider : SymbolProcessorProvider {
     override fun create(

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/KspOptions.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/KspOptions.kt
@@ -19,7 +19,5 @@ enum class KspOptions {
     KOIN_CONFIG_CHECK,
     KOIN_DEFAULT_MODULE,
 
-    //TODO Remove isComposeViewModelActive with Koin 4
-    USE_COMPOSE_VIEWMODEL,
     KOIN_USE_COMPOSE_VIEWMODEL
 }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/KoinCodeGenerator.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/KoinCodeGenerator.kt
@@ -25,7 +25,7 @@ class KoinCodeGenerator(
     val codeGenerator: CodeGenerator,
     val logger: KSPLogger,
     //TODO Remove isComposeViewModelActive with Koin 4
-    val isComposeViewModelActive: Boolean
+    val isViewModelMPActive: Boolean
 ) {
     lateinit var resolver: Resolver
 
@@ -57,7 +57,7 @@ class KoinCodeGenerator(
 
         if (defaultModule.alreadyGenerated == false && hasDefaultDefinitions){
             defaultModule.setCurrentDefinitionsToExternals()
-            DefaultModuleWriter(codeGenerator, resolver, defaultModule, generateDefaultModule).writeModule(isComposeViewModelActive)
+            DefaultModuleWriter(codeGenerator, resolver, defaultModule, generateDefaultModule).writeModule(isViewModelMPActive)
         }
     }
 
@@ -67,7 +67,7 @@ class KoinCodeGenerator(
         checkAlreadyGenerated(module)
 
         if (module.alreadyGenerated == false){
-            ClassModuleWriter(codeGenerator, resolver, module).writeModule(isComposeViewModelActive)
+            ClassModuleWriter(codeGenerator, resolver, module).writeModule(isViewModelMPActive)
         }
     }
 

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/ModuleWriter.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/ModuleWriter.kt
@@ -21,8 +21,8 @@ import com.google.devtools.ksp.processing.Resolver
 import org.koin.compiler.generator.DefinitionWriter.Companion.CREATED_AT_START
 import org.koin.compiler.generator.DefinitionWriter.Companion.TAB
 import org.koin.compiler.generator.ext.getNewFile
-import org.koin.compiler.metadata.KOIN_VIEWMODEL
-import org.koin.compiler.metadata.KOIN_VIEWMODEL_COMPOSE
+import org.koin.compiler.metadata.KOIN_VIEWMODEL_ANDROID
+import org.koin.compiler.metadata.KOIN_VIEWMODEL_MP
 import org.koin.compiler.metadata.KoinMetaData
 import org.koin.compiler.scanner.ext.filterForbiddenKeywords
 import org.koin.compiler.generator.ext.toSourceString
@@ -49,12 +49,12 @@ abstract class ModuleWriter(
     private val generatedField = "${module.packageName("_")}_${module.name}"
 
     //TODO Remove isComposeViewModelActive with Koin 4
-    fun writeModule(isComposeViewModelActive: Boolean) {
+    fun writeModule(isViewModelMPActive: Boolean) {
         fileStream = createFileStream()
         definitionFactory = DefinitionWriterFactory(resolver, fileStream!!)
 
         writeHeader()
-        writeHeaderImports(isComposeViewModelActive)
+        writeHeaderImports(isViewModelMPActive)
 
         if (hasExternalDefinitions) {
             writeExternalDefinitionImports()
@@ -91,19 +91,19 @@ abstract class ModuleWriter(
         writeln(MODULE_HEADER)
     }
 
-    open fun writeHeaderImports(isComposeViewModelActive: Boolean) {
-        writeln(generateImports(module.definitions, isComposeViewModelActive))
+    open fun writeHeaderImports(isViewModelMPActive: Boolean) {
+        writeln(generateImports(module.definitions, isViewModelMPActive))
     }
 
     private fun generateImports(
         definitions: List<KoinMetaData.Definition>,
-        isComposeViewModelActive: Boolean
+        isViewModelMPActive: Boolean
     ): String {
         return definitions.map { definition -> definition.keyword }
             .toSet()
             .mapNotNull { keyword ->
-                if (isComposeViewModelActive && keyword == KOIN_VIEWMODEL) {
-                    KOIN_VIEWMODEL_COMPOSE.import.let { "import $it" }
+                if (isViewModelMPActive && keyword == KOIN_VIEWMODEL_ANDROID) {
+                    KOIN_VIEWMODEL_MP.import.let { "import $it" }
                 } else {
                     keyword.import?.let { "import $it" }
                 }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/AnnotationMetadata.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/AnnotationMetadata.kt
@@ -37,18 +37,17 @@ val SINGLETON = DefinitionAnnotation("single", annotationType = Singleton::class
 val FACTORY = DefinitionAnnotation("factory", annotationType = Factory::class)
 val SCOPE = DefinitionAnnotation("scoped", annotationType = Scope::class)
 val SCOPED = DefinitionAnnotation("scoped", annotationType = Scoped::class)
-val KOIN_VIEWMODEL = DefinitionAnnotation("viewModel", "org.koin.androidx.viewmodel.dsl.viewModel", KoinViewModel::class)
 
-//TODO Remove isComposeViewModelActive with Koin 4
-val KOIN_VIEWMODEL_COMPOSE = DefinitionAnnotation("viewModel", "org.koin.core.module.dsl.viewModel", KoinViewModel::class)
+val KOIN_VIEWMODEL_ANDROID = DefinitionAnnotation("viewModel", "org.koin.androidx.viewmodel.dsl.viewModel", KoinViewModel::class)
+val KOIN_VIEWMODEL_MP = DefinitionAnnotation("viewModel", "org.koin.core.module.dsl.viewModel", KoinViewModel::class)
 
 val KOIN_WORKER = DefinitionAnnotation("worker", "org.koin.androidx.workmanager.dsl.worker", KoinWorker::class)
 
-val DEFINITION_ANNOTATION_LIST = listOf(SINGLE, SINGLETON,FACTORY, SCOPE, SCOPED,KOIN_VIEWMODEL, KOIN_WORKER)
+val DEFINITION_ANNOTATION_LIST = listOf(SINGLE, SINGLETON,FACTORY, SCOPE, SCOPED,KOIN_VIEWMODEL_ANDROID, KOIN_WORKER)
 val DEFINITION_ANNOTATION_LIST_TYPES = DEFINITION_ANNOTATION_LIST.map { it.annotationType }
 val DEFINITION_ANNOTATION_LIST_NAMES = DEFINITION_ANNOTATION_LIST.map { it.annotationName?.lowercase(Locale.getDefault()) }
 
-val SCOPE_DEFINITION_ANNOTATION_LIST = listOf(SCOPED, FACTORY, KOIN_VIEWMODEL, KOIN_WORKER)
+val SCOPE_DEFINITION_ANNOTATION_LIST = listOf(SCOPED, FACTORY, KOIN_VIEWMODEL_ANDROID, KOIN_WORKER)
 val SCOPE_DEFINITION_ANNOTATION_LIST_NAMES = SCOPE_DEFINITION_ANNOTATION_LIST.map { it.annotationName?.lowercase(Locale.getDefault()) }
 
 
@@ -61,7 +60,7 @@ fun getExtraScopeAnnotation(annotations: Map<String, KSAnnotation>): DefinitionA
     val definitionAnnotation = when (key) {
         SCOPED.annotationName -> SCOPED
         FACTORY.annotationName -> FACTORY
-        KOIN_VIEWMODEL.annotationName -> KOIN_VIEWMODEL
+        KOIN_VIEWMODEL_ANDROID.annotationName -> KOIN_VIEWMODEL_ANDROID
         KOIN_WORKER.annotationName -> KOIN_WORKER
         else -> null
     }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/ClassComponentScanner.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/ClassComponentScanner.kt
@@ -69,8 +69,8 @@ class ClassComponentScanner(
             FACTORY.annotationName -> {
                 createClassDefinition(FACTORY,packageName, qualifier, className, ctorParams, allBindings, isExpect = isExpect)
             }
-            KOIN_VIEWMODEL.annotationName -> {
-                createClassDefinition(KOIN_VIEWMODEL,packageName, qualifier, className, ctorParams, allBindings, isExpect = isExpect)
+            KOIN_VIEWMODEL_ANDROID.annotationName -> {
+                createClassDefinition(KOIN_VIEWMODEL_ANDROID,packageName, qualifier, className, ctorParams, allBindings, isExpect = isExpect)
             }
             KOIN_WORKER.annotationName -> {
                 createClassDefinition(KOIN_WORKER,packageName, qualifier, className, ctorParams, allBindings, isExpect = isExpect)

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/FunctionScanner.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/FunctionScanner.kt
@@ -56,8 +56,8 @@ abstract class FunctionScanner(
             FACTORY.annotationName -> {
                 createDefinition(FACTORY,packageName,qualifier,functionName,functionParameters,allBindings, isExpect = isExpect)
             }
-            KOIN_VIEWMODEL.annotationName -> {
-                createDefinition(KOIN_VIEWMODEL,packageName,qualifier,functionName,functionParameters,allBindings, isExpect = isExpect)
+            KOIN_VIEWMODEL_ANDROID.annotationName -> {
+                createDefinition(KOIN_VIEWMODEL_ANDROID,packageName,qualifier,functionName,functionParameters,allBindings, isExpect = isExpect)
             }
             KOIN_WORKER.annotationName -> {
                 createDefinition(KOIN_WORKER,packageName,qualifier,functionName,functionParameters,allBindings, isExpect = isExpect)


### PR DESCRIPTION
Clean up old code for ViewModel generation to take Koin 4.0 default ViewModel API.
Allow to keep it by default to true. can be disabled