### PR TITLE
fix: `Scope.getValue` returns KSP type name

### DIFF
--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinMetaData.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinMetaData.kt
@@ -103,7 +103,7 @@ sealed class KoinMetaData {
         fun getValue(): String {
             return when (this) {
                 is StringScope -> name
-                is ClassScope -> "${type.packageName}.${type.simpleName}"
+                is ClassScope -> "${type.packageName.asString()}.${type.simpleName.asString()}"
             }
         }
     }


### PR DESCRIPTION
Both `packageName` and `simpleName` are of the type `KSNameImpl` which does not override the `toString` properly, thus returning the standard JVM `the.library.package.MyClass@13371337` output.
Looking through the KSP code, I can't seem to find any indication that this previously implicitly used `toString` ever returned the correct output. Thus, I'm fixing it and expecting no breaking changes caused by old KSP versions.

Before:
![image showing `getScope("[ksp KSNameImpl FQDN].[ksp KSNameImpl FQDN]")`](https://github.com/user-attachments/assets/1034d110-046a-464c-a8d6-43cbcbde73d5)

After:
![image showing `getScope("my.app.package.MyScope")`](https://github.com/user-attachments/assets/3a4db888-73d3-4ea4-b248-f57a56170c4e)

Let me know if the interest in a Backport exists.