### PR TITLE
Fix verification engine for KSP 2 / Kotlin 2

### DIFF
--- a/examples/android-coffee-maker/src/main/java/org/koin/sample/androidx/di/AppModules.kt
+++ b/examples/android-coffee-maker/src/main/java/org/koin/sample/androidx/di/AppModules.kt
@@ -4,11 +4,12 @@ import org.koin.core.annotation.ComponentScan
 import org.koin.core.annotation.Module
 import org.koin.sample.android.library.CommonModule
 import org.koin.sample.androidx.repository.RepositoryModule
+import org.koin.sample.clients.ClientModule
 
 @Module(includes = [DataModule::class])
 @ComponentScan("org.koin.sample.androidx.app")
 class AppModule
 
-@Module(includes = [CommonModule::class, RepositoryModule::class])
+@Module(includes = [CommonModule::class, ClientModule::class, RepositoryModule::class])
 @ComponentScan("org.koin.sample.androidx.data")
 internal class DataModule

--- a/examples/android-coffee-maker/src/test/java/AndroidModuleTest.kt
+++ b/examples/android-coffee-maker/src/test/java/AndroidModuleTest.kt
@@ -1,10 +1,12 @@
 package org.koin.sample.androidx
 
+import io.ktor.client.HttpClient
 import it.example.component.ExampleSingleton
 import org.junit.Test
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.core.parameter.parametersOf
+import org.koin.core.qualifier.named
 import org.koin.ksp.generated.module
 import org.koin.sample.android.library.CommonRepository
 import org.koin.sample.android.library.MyScope
@@ -40,6 +42,8 @@ class AndroidModuleTest {
         assert(koin.getOrNull<MyDataConsumer>() != null)
 
         assert(koin.getOrNull<ExampleSingleton>() != null)
+
+        assert(koin.get<HttpClient>(named("clientA")) != koin.get<HttpClient>(named("clientB")))
 
 
         stopKoin()

--- a/examples/android-library/build.gradle.kts
+++ b/examples/android-library/build.gradle.kts
@@ -38,7 +38,8 @@ dependencies {
     implementation(libs.android.appcompat)
     ksp(libs.koin.ksp)
     implementation(project(":coffee-maker-module"))
-
+    api(libs.ktor.core)
+    implementation(libs.ktor.cio)
     testImplementation(libs.koin.test)
 }
 

--- a/examples/android-library/src/main/java/org/koin/sample/clients/ClientModule.kt
+++ b/examples/android-library/src/main/java/org/koin/sample/clients/ClientModule.kt
@@ -1,0 +1,26 @@
+package org.koin.sample.clients
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import org.koin.core.annotation.Module
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
+
+@Module(includes = [ClientModuleA::class, ClientModuleB::class])
+class ClientModule
+
+@Module
+class ClientModuleA {
+
+    @Single
+    @Named("clientA")
+    fun createClient() = HttpClient(CIO) {}
+}
+
+@Module
+class ClientModuleB {
+
+    @Single
+    @Named("clientB")
+    fun createClient() = HttpClient(CIO) {}
+}

--- a/examples/coffee-maker/src/main/kotlin/org/koin/example/CoffeeApp.kt
+++ b/examples/coffee-maker/src/main/kotlin/org/koin/example/CoffeeApp.kt
@@ -4,7 +4,6 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.koin.core.context.startKoin
 import org.koin.core.logger.Level
-import org.koin.core.time.measureDuration
 import org.koin.example.coffee.CoffeeMaker
 import org.koin.example.di.CoffeeAppModule
 import org.koin.example.di.CoffeeTesterModule
@@ -12,6 +11,7 @@ import org.koin.example.tea.TeaModule
 import org.koin.example.test.ext.ExternalModule
 import org.koin.example.test.scope.ScopeModule
 import org.koin.ksp.generated.*
+import kotlin.time.measureTime
 
 class CoffeeApp : KoinComponent {
     val maker: CoffeeMaker by inject()
@@ -37,13 +37,8 @@ fun main() {
     }
 
     val coffeeShop = CoffeeApp()
-    measureDuration("Got Coffee") {
+    val t = measureTime {
         coffeeShop.maker.brew()
     }
-}
-
-fun measureDuration(msg: String, code: () -> Unit): Double {
-    val duration = measureDuration(code)
-    println("$msg in $duration ms")
-    return duration
+    println("Got Coffee in $t")
 }

--- a/examples/coffee-maker/src/test/java/CoffeeAppTest.kt
+++ b/examples/coffee-maker/src/test/java/CoffeeAppTest.kt
@@ -11,7 +11,6 @@ import org.koin.example.coffee.MyDetachCoffeeComponent
 import org.koin.example.coffee.pump.PumpCounter
 import org.koin.example.di.CoffeeAppModule
 import org.koin.example.di.CoffeeTesterModule
-import org.koin.example.measureDuration
 import org.koin.example.tea.TeaModule
 import org.koin.example.tea.TeaPot
 import org.koin.example.test.CoffeeMakerTester
@@ -22,6 +21,7 @@ import org.koin.example.test.include.IncludedComponent
 import org.koin.example.test.scope.*
 import org.koin.ksp.generated.module
 import org.koin.mp.KoinPlatformTools
+import kotlin.time.measureTime
 
 class CoffeeAppTest {
 
@@ -44,9 +44,10 @@ class CoffeeAppTest {
         }
 
         val coffeeShop = CoffeeApp()
-        measureDuration("Got Coffee") {
+        val time = measureTime {
             coffeeShop.maker.brew()
         }
+        println("Got Coffee in $time")
 
         // Tests
         val koin = KoinPlatformTools.defaultContext().get()

--- a/examples/gradle/libs.versions.toml
+++ b/examples/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ junit = "4.13.2"
 # Android
 agp = "8.3.2"
 androidCompat = "1.7.0"
+ktor = "2.3.12"
 
 [libraries]
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
@@ -21,6 +22,8 @@ koin-ksp = { module = "io.insert-koin:koin-ksp-compiler", version.ref = "koinAnn
 ksp-api = {module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp"}
 android-appcompat = {module = "androidx.appcompat:appcompat", version.ref = "androidCompat"}
 junit = {module = "junit:junit",version.ref ="junit"}
+ktor-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 
 [plugins]
 #kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/examples/other-ksp/src/main/kotlin/org/koin/example/scope/ScopeModule.kt
+++ b/examples/other-ksp/src/main/kotlin/org/koin/example/scope/ScopeModule.kt
@@ -10,6 +10,7 @@ public class MyScope
 @Scoped
 public class MyScopedInstance
 
+@Scope(name = "my_scope")
 @Factory
 public class MyScopeFactory(
     public val oc : MyOtherComponent,

--- a/examples/other-ksp/src/test/kotlin/org.koin.example/TestModule.kt
+++ b/examples/other-ksp/src/test/kotlin/org.koin.example/TestModule.kt
@@ -58,13 +58,12 @@ class TestModule {
         assertTrue { animals.any { it is Cat } }
 
         val scope = koin.createScope("my_scope_id", named("my_scope"))
-
         assertTrue {
-            koin.get<MyScopeFactory>().msi == scope.get<MyScopedInstance>()
+            scope.get<MyScopeFactory>().msi == scope.get<MyScopedInstance>()
         }
 
         assertTrue {
-            koin.get<MyScopeFactory>().msi == koin.get<MyScopeFactory>().msi
+            scope.get<MyScopeFactory>().msi == scope.get<MyScopeFactory>().msi
         }
 
         assertFailsWith(NoDefinitionFoundException::class) {

--- a/examples/test.sh
+++ b/examples/test.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 
 ./gradlew testDebug --no-build-cache
+./gradlew :other-ksp:test :coffee-maker:test :compile-perf:test --no-build-cache

--- a/projects/koin-annotations/src/commonMain/kotlin/org/koin/core/annotation/CoreAnnotations.kt
+++ b/projects/koin-annotations/src/commonMain/kotlin/org/koin/core/annotation/CoreAnnotations.kt
@@ -215,11 +215,3 @@ annotation class ComponentScan(val value: String = "")
  */
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER)
 annotation class Provided
-
-/**
- * Internal usage for components discovery in generated package
- *
- * @param value: package of declared definition
- */
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FIELD, AnnotationTarget.FUNCTION)
-annotation class Definition(val value: String = "")

--- a/projects/koin-annotations/src/commonMain/kotlin/org/koin/meta/MetaAnnotations.kt
+++ b/projects/koin-annotations/src/commonMain/kotlin/org/koin/meta/MetaAnnotations.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.koin.meta
+
+/**
+ * All following Annotations are intended for Internal use only
+ *
+ * @author Arnaud Giuliani
+ */
+
+/**
+ * Meta Definition annotation to help represents
+ * - Definition full path
+ * - Parameters Tags to check
+ */
+@Target(AnnotationTarget.CLASS)
+annotation class MetaDefinition(val value: String = "",val parameters : Array<String> = [])
+
+/**
+ * Meta Definition annotation to help represents
+ * - Definition full path
+ * - Includes Module Tags to check
+ */
+@Target(AnnotationTarget.CLASS)
+annotation class MetaModule(val value: String = "",val includes : Array<String> = [])

--- a/projects/koin-annotations/src/commonMain/kotlin/org/koin/meta/annotations/MetaAnnotations.kt
+++ b/projects/koin-annotations/src/commonMain/kotlin/org/koin/meta/annotations/MetaAnnotations.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.koin.meta
+package org.koin.meta.annotations
 
 /**
  * All following Annotations are intended for Internal use only
@@ -22,17 +22,25 @@ package org.koin.meta
  */
 
 /**
+ * Internal usage for components discovery in generated package
+ *
+ * @param value: package of declared definition
+ */
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FIELD, AnnotationTarget.FUNCTION)
+annotation class ExternalDefinition(val value: String = "")
+
+/**
  * Meta Definition annotation to help represents
- * - Definition full path
- * - Parameters Tags to check
+ * @param value: Definition full path
+ * @param parameters - Parameters Tags to check
  */
 @Target(AnnotationTarget.CLASS)
 annotation class MetaDefinition(val value: String = "",val parameters : Array<String> = [])
 
 /**
  * Meta Definition annotation to help represents
- * - Definition full path
- * - Includes Module Tags to check
+ * @param value: Definition full path
+ * @param includes - Includes Module Tags to check
  */
 @Target(AnnotationTarget.CLASS)
 annotation class MetaModule(val value: String = "",val includes : Array<String> = [])

--- a/projects/koin-annotations/src/commonMain/kotlin/org/koin/meta/annotations/MetaAnnotations.kt
+++ b/projects/koin-annotations/src/commonMain/kotlin/org/koin/meta/annotations/MetaAnnotations.kt
@@ -33,9 +33,10 @@ annotation class ExternalDefinition(val value: String = "")
  * Meta Definition annotation to help represents
  * @param value: Definition full path
  * @param dependencies - Parameters Tags to check
+ * @param scope - Scope where it's declared
  */
 @Target(AnnotationTarget.CLASS)
-annotation class MetaDefinition(val value: String = "", val dependencies: Array<String> = [])
+annotation class MetaDefinition(val value: String = "", val dependencies: Array<String> = [], val scope : String = "")
 
 /**
  * Meta Definition annotation to help represents

--- a/projects/koin-annotations/src/commonMain/kotlin/org/koin/meta/annotations/MetaAnnotations.kt
+++ b/projects/koin-annotations/src/commonMain/kotlin/org/koin/meta/annotations/MetaAnnotations.kt
@@ -32,10 +32,10 @@ annotation class ExternalDefinition(val value: String = "")
 /**
  * Meta Definition annotation to help represents
  * @param value: Definition full path
- * @param parameters - Parameters Tags to check
+ * @param dependencies - Parameters Tags to check
  */
 @Target(AnnotationTarget.CLASS)
-annotation class MetaDefinition(val value: String = "",val parameters : Array<String> = [])
+annotation class MetaDefinition(val value: String = "", val dependencies: Array<String> = [])
 
 /**
  * Meta Definition annotation to help represents
@@ -43,4 +43,4 @@ annotation class MetaDefinition(val value: String = "",val parameters : Array<St
  * @param includes - Includes Module Tags to check
  */
 @Target(AnnotationTarget.CLASS)
-annotation class MetaModule(val value: String = "",val includes : Array<String> = [])
+annotation class MetaModule(val value: String = "", val includes: Array<String> = [])

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
@@ -62,16 +62,18 @@ class BuilderProcessor(
         logger.logging("Generate code ...")
         koinCodeGenerator.generateModules(moduleList, defaultModule, isDefaultModuleActive())
 
-        // Tags are used to verify generated content (KMP)
-        koinTagWriter.writeAllTags(moduleList, defaultModule)
+        val isConfigCheckActive = isConfigCheckActive()
 
-        if (isConfigCheckActive()) {
+        // Tags are used to verify generated content (KMP)
+        koinTagWriter.writeAllTags(moduleList, defaultModule, isConfigCheckActive)
+
+        if (isConfigCheckActive) {
             logger.warn("Check Configuration ...")
 
-            val moduleList = koinMetaDataScanner.scanKoinModules(
-                defaultModule,
-                resolver
-            )
+//            val moduleList = koinMetaDataScanner.scanKoinModules(
+//                defaultModule,
+//                resolver
+//            )
             val allModules = moduleList + defaultModule
             koinConfigChecker.verifyDefinitionDeclarations(allModules, resolver)
             koinConfigChecker.verifyModuleIncludes(allModules, resolver)

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
@@ -20,10 +20,10 @@ import com.google.devtools.ksp.symbol.KSAnnotated
 import org.koin.compiler.KspOptions.*
 import org.koin.compiler.generator.KoinCodeGenerator
 import org.koin.compiler.metadata.KoinMetaData
-import org.koin.compiler.scanner.KoinMetaDataScanner
-import org.koin.compiler.verify.KoinConfigChecker
 import org.koin.compiler.metadata.KoinTagWriter
+import org.koin.compiler.scanner.KoinMetaDataScanner
 import org.koin.compiler.scanner.KoinTagMetaDataScanner
+import org.koin.compiler.verify.KoinConfigChecker
 import kotlin.time.measureTime
 
 class BuilderProcessor(
@@ -71,20 +71,20 @@ class BuilderProcessor(
         val isAlreadyGenerated = codeGenerator.generatedFile.isEmpty()
         if (isConfigCheckActive && isAlreadyGenerated) {
             logger.warn("Koin Configuration Check ...")
-
-            val metaTagScanner = KoinTagMetaDataScanner(logger, resolver)
-            val invalidsMetaSymbols = metaTagScanner.findInvalidSymbols()
-            if (invalidsMetaSymbols.isNotEmpty()) {
-                logger.logging("Invalid symbols found (${invalidsMetaSymbols.size}), waiting for next round")
-                return invalidSymbols
-            }
-
-            val checker = KoinConfigChecker(logger, resolver)
             val t = measureTime {
+
+                val metaTagScanner = KoinTagMetaDataScanner(logger, resolver)
+                val invalidsMetaSymbols = metaTagScanner.findInvalidSymbols()
+                if (invalidsMetaSymbols.isNotEmpty()) {
+                    logger.logging("Invalid symbols found (${invalidsMetaSymbols.size}), waiting for next round")
+                    return invalidSymbols
+                }
+
+                val checker = KoinConfigChecker(logger, resolver)
                 checker.verifyMetaModules(metaTagScanner.findMetaModules())
                 checker.verifyMetaDefinitions(metaTagScanner.findMetaDefinitions())
             }
-            logger.warn("Koin Configuration Check executed in $t")
+            logger.warn("Koin Configuration Check done in $t")
         }
         return emptyList()
     }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
@@ -69,7 +69,7 @@ class BuilderProcessor(
 
         val isAlreadyGenerated = codeGenerator.generatedFile.isEmpty()
         if (isConfigCheckActive && isAlreadyGenerated) {
-            logger.warn("Check Configuration ...")
+            logger.warn("Check Koin Configuration ...")
 
             val metaTagScanner = KoinTagMetaDataScanner(logger, resolver)
             val invalidsMetaSymbols = metaTagScanner.findInvalidSymbols()

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
@@ -33,7 +33,6 @@ class BuilderProcessor(
     private val isViewModelMPActive = isKoinViewModelMPActive()
     private val koinCodeGenerator = KoinCodeGenerator(codeGenerator, logger, isViewModelMPActive)
     private val koinMetaDataScanner = KoinMetaDataScanner(logger)
-    private val koinConfigChecker = KoinConfigChecker(codeGenerator, logger)
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         initComponents(resolver)
@@ -70,13 +69,12 @@ class BuilderProcessor(
         if (isConfigCheckActive) {
             logger.warn("Check Configuration ...")
 
-//            val moduleList = koinMetaDataScanner.scanKoinModules(
-//                defaultModule,
-//                resolver
-//            )
             val allModules = moduleList + defaultModule
-            koinConfigChecker.verifyDefinitionDeclarations(allModules, resolver)
-            koinConfigChecker.verifyModuleIncludes(allModules, resolver)
+
+            val isAlreadyGenerated = codeGenerator.generatedFile.isEmpty()
+            if (isAlreadyGenerated){
+                KoinConfigChecker(logger, resolver).verify(allModules)
+            }
         }
         return emptyList()
     }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
@@ -25,7 +25,7 @@ import org.koin.compiler.verify.KoinConfigChecker
 import org.koin.compiler.metadata.KoinTagWriter
 
 class BuilderProcessor(
-    codeGenerator: CodeGenerator,
+    private val codeGenerator: CodeGenerator,
     private val logger: KSPLogger,
     private val options: Map<String, String>
 ) : SymbolProcessor {
@@ -33,7 +33,6 @@ class BuilderProcessor(
     private val isViewModelMPActive = isKoinViewModelMPActive()
     private val koinCodeGenerator = KoinCodeGenerator(codeGenerator, logger, isViewModelMPActive)
     private val koinMetaDataScanner = KoinMetaDataScanner(logger)
-    private val koinTagWriter = KoinTagWriter(codeGenerator, logger)
     private val koinConfigChecker = KoinConfigChecker(codeGenerator, logger)
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
@@ -65,7 +64,8 @@ class BuilderProcessor(
         val isConfigCheckActive = isConfigCheckActive()
 
         // Tags are used to verify generated content (KMP)
-        koinTagWriter.writeAllTags(moduleList, defaultModule, isConfigCheckActive)
+        KoinTagWriter(codeGenerator, logger, resolver, isConfigCheckActive)
+            .writeAllTags(moduleList, defaultModule)
 
         if (isConfigCheckActive) {
             logger.warn("Check Configuration ...")
@@ -83,7 +83,6 @@ class BuilderProcessor(
 
     private fun initComponents(resolver: Resolver) {
         koinCodeGenerator.resolver = resolver
-        koinTagWriter.resolver = resolver
     }
 
     private fun isConfigCheckActive(): Boolean {

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
@@ -22,7 +22,7 @@ import org.koin.compiler.generator.KoinCodeGenerator
 import org.koin.compiler.metadata.KoinMetaData
 import org.koin.compiler.scanner.KoinMetaDataScanner
 import org.koin.compiler.verify.KoinConfigChecker
-import org.koin.compiler.verify.KoinTagWriter
+import org.koin.compiler.metadata.KoinTagWriter
 
 class BuilderProcessor(
     codeGenerator: CodeGenerator,
@@ -68,8 +68,11 @@ class BuilderProcessor(
         if (isConfigCheckActive()) {
             logger.warn("Check Configuration ...")
 
+            val moduleList = koinMetaDataScanner.scanKoinModules(
+                defaultModule,
+                resolver
+            )
             val allModules = moduleList + defaultModule
-
             koinConfigChecker.verifyDefinitionDeclarations(allModules, resolver)
             koinConfigChecker.verifyModuleIncludes(allModules, resolver)
         }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
@@ -62,12 +62,13 @@ class BuilderProcessor(
         logger.logging("Generate code ...")
         koinCodeGenerator.generateModules(moduleList, defaultModule, isDefaultModuleActive())
 
+        // Tags are used to verify generated content (KMP)
+        koinTagWriter.writeAllTags(moduleList, defaultModule)
 
         if (isConfigCheckActive()) {
             logger.warn("Check Configuration ...")
 
             val allModules = moduleList + defaultModule
-            koinTagWriter.writeAllTags(moduleList, defaultModule)
 
             koinConfigChecker.verifyDefinitionDeclarations(allModules, resolver)
             koinConfigChecker.verifyModuleIncludes(allModules, resolver)

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/BuilderProcessor.kt
@@ -24,6 +24,7 @@ import org.koin.compiler.scanner.KoinMetaDataScanner
 import org.koin.compiler.verify.KoinConfigChecker
 import org.koin.compiler.metadata.KoinTagWriter
 import org.koin.compiler.scanner.KoinTagMetaDataScanner
+import kotlin.time.measureTime
 
 class BuilderProcessor(
     private val codeGenerator: CodeGenerator,
@@ -69,7 +70,7 @@ class BuilderProcessor(
 
         val isAlreadyGenerated = codeGenerator.generatedFile.isEmpty()
         if (isConfigCheckActive && isAlreadyGenerated) {
-            logger.warn("Check Koin Configuration ...")
+            logger.warn("Koin Configuration Check ...")
 
             val metaTagScanner = KoinTagMetaDataScanner(logger, resolver)
             val invalidsMetaSymbols = metaTagScanner.findInvalidSymbols()
@@ -79,8 +80,11 @@ class BuilderProcessor(
             }
 
             val checker = KoinConfigChecker(logger, resolver)
-            checker.verifyMetaModules(metaTagScanner.findMetaModules())
-            checker.verifyMetaDefinitions(metaTagScanner.findMetaDefinitions())
+            val t = measureTime {
+                checker.verifyMetaModules(metaTagScanner.findMetaModules())
+                checker.verifyMetaDefinitions(metaTagScanner.findMetaDefinitions())
+            }
+            logger.warn("Koin Configuration Check executed in $t")
         }
         return emptyList()
     }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/DefinitionWriter.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/DefinitionWriter.kt
@@ -22,6 +22,7 @@ import org.koin.compiler.generator.KoinCodeGenerator.Companion.LOGGER
 import org.koin.compiler.metadata.KoinMetaData
 import org.koin.compiler.metadata.KoinMetaData.Module.Companion.DEFINE_PREFIX
 import org.koin.compiler.metadata.SINGLE
+import org.koin.compiler.metadata.TagFactory
 import org.koin.compiler.scanner.ext.filterForbiddenKeywords
 import org.koin.compiler.verify.getResolution
 import java.io.OutputStream
@@ -40,7 +41,7 @@ class DefinitionWriter(
         }
 
         if (def.alreadyGenerated == true){
-            LOGGER.logging("skip ${def.label} -> ${def.getTagName()} - already generated")
+            LOGGER.logging("skip ${def.label} -> ${TagFactory.getTag(def)} - already generated")
         } else {
             if (def.isExpect.not()){
                 LOGGER.logging("write definition ${def.label} ...")

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/DefinitionWriter.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/DefinitionWriter.kt
@@ -23,7 +23,7 @@ import org.koin.compiler.metadata.KoinMetaData
 import org.koin.compiler.metadata.KoinMetaData.Module.Companion.DEFINE_PREFIX
 import org.koin.compiler.metadata.SINGLE
 import org.koin.compiler.scanner.ext.filterForbiddenKeywords
-import org.koin.compiler.verify.ext.getResolution
+import org.koin.compiler.verify.getResolution
 import java.io.OutputStream
 
 class DefinitionWriter(

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/DefinitionWriter.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/DefinitionWriter.kt
@@ -91,7 +91,7 @@ class DefinitionWriter(
         ctor: String,
         binds: String
     ) {
-        writeln("@Definition(\"${def.packageName}\")")
+        writeln("@ExternalDefinition(\"${def.packageName}\")")
         writeln("public fun Module.$DEFINE_PREFIX${def.label}() : KoinDefinition<*> = ${def.keyword.keyword}($qualifier$createAtStart) { ${param}${prefix}$ctor } $binds")
     }
 

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/DefinitionWriter.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/DefinitionWriter.kt
@@ -24,7 +24,7 @@ import org.koin.compiler.metadata.KoinMetaData.Module.Companion.DEFINE_PREFIX
 import org.koin.compiler.metadata.SINGLE
 import org.koin.compiler.metadata.TagFactory
 import org.koin.compiler.scanner.ext.filterForbiddenKeywords
-import org.koin.compiler.verify.getResolution
+import org.koin.compiler.resolver.getResolution
 import java.io.OutputStream
 
 class DefinitionWriter(

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/KoinCodeGenerator.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/KoinCodeGenerator.kt
@@ -19,7 +19,7 @@ import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import org.koin.compiler.metadata.KoinMetaData
-import org.koin.compiler.verify.ext.getResolution
+import org.koin.compiler.verify.getResolution
 
 class KoinCodeGenerator(
     val codeGenerator: CodeGenerator,

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/KoinCodeGenerator.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/KoinCodeGenerator.kt
@@ -19,7 +19,7 @@ import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import org.koin.compiler.metadata.KoinMetaData
-import org.koin.compiler.verify.getResolution
+import org.koin.compiler.resolver.getResolution
 
 class KoinCodeGenerator(
     val codeGenerator: CodeGenerator,

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/ModuleWriter.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/ModuleWriter.kt
@@ -82,7 +82,7 @@ abstract class ModuleWriter(
 
     private fun writeExternalDefinitionImports() {
         writeln("""
-            import org.koin.core.annotation.Definition
+            import org.koin.meta.annotations.ExternalDefinition
             import org.koin.core.definition.KoinDefinition
         """.trimIndent())
     }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinMetaData.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinMetaData.kt
@@ -42,16 +42,10 @@ sealed class KoinMetaData {
 
         var alreadyGenerated : Boolean? = null
 
-        fun getTagName() = packageName.camelCase() +
-                            name +
-                            if (isExpect) "Expect" else "" +
-                            if (isActual) "Actual" else ""
-
         fun packageName(separator: String): String {
             return if (isDefault) ""
             else {
-                val default = Locale.getDefault()
-                packageName.split(".").joinToString(separator) { it.lowercase(default) }
+                splitPackage(packageName, separator)
             }
         }
 
@@ -88,12 +82,7 @@ sealed class KoinMetaData {
         val className : String,
         val isExpect : Boolean,
         val isActual : Boolean
-    ){
-        fun getTagName() = packageName.camelCase() +
-                           className.capitalize() +
-                           if (isExpect) "Expect" else "" +
-                           if (isActual) "Actual" else ""
-    }
+    )
 
     enum class ModuleType {
         FIELD, CLASS, OBJECT;
@@ -169,13 +158,6 @@ sealed class KoinMetaData {
         fun isType(keyword: DefinitionAnnotation): Boolean = this.keyword == keyword
 
         val packageNamePrefix : String = if (packageName.isEmpty()) "" else "${packageName}."
-
-        fun getTagName() = packageName.camelCase() +
-                            label.capitalize() +
-                            (qualifier?.let { "Q_$it" } ?: "") +
-                            (scope?.getTagValue()?.camelCase()?.let { "S_" } ?: "") +
-                            if (isExpect) "Expect" else "" +
-                            if (isActual) "Actual" else ""
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
@@ -272,6 +254,9 @@ sealed class KoinMetaData {
         Single, List, Lazy
     }
 }
+
+internal fun splitPackage(packageName : String, separator: String, default: Locale = Locale.getDefault()) : String =
+    packageName.split(".").joinToString(separator) { it.lowercase(default) }
 
 
 private fun KSDeclaration.getQualifiedName(): String {

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinTagWriter.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinTagWriter.kt
@@ -112,6 +112,22 @@ class KoinTagWriter(
     ) {
         writeDefinitionTag(def)
         def.bindings.forEach { writeBindingTag(def,it) }
+        if (def.isScoped() && def.scope is KoinMetaData.Scope.ClassScope){
+            writeScopeTag(def.scope.type)
+        }
+    }
+
+    private fun writeScopeTag(
+        scope: KSDeclaration
+    ) {
+        val name = scope.qualifiedName?.asString()
+        if (name !in typeWhiteList) {
+            val tag = TagFactory.getTag(scope)
+            val alreadyGenerated = resolver.isAlreadyExisting(tag)
+            if (tag !in alreadyDeclaredTags && !alreadyGenerated) {
+                writeTag(tag)
+            }
+        }
     }
 
     private fun writeDefinitionTag(

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinTagWriter.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinTagWriter.kt
@@ -123,6 +123,10 @@ class KoinTagWriter(
         if (!definition.isExpect && definition.alreadyGenerated == false){
             val tag = TagFactory.getTag(definition)
             if (tag !in alreadyDeclaredTags) {
+                if (isConfigCheckActive){
+                    val metaLine = MetaAnnotationFactory.generate(definition)
+                    writeMeta(metaLine)
+                }
                 writeTag(tag)
             }
         }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinTagWriter.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinTagWriter.kt
@@ -111,7 +111,7 @@ class KoinTagWriter(
         def: KoinMetaData.Definition,
     ) {
         writeDefinitionTag(def)
-        def.bindings.forEach { writeBindingTag(it) }
+        def.bindings.forEach { writeBindingTag(def,it) }
     }
 
     private fun writeDefinitionTag(
@@ -134,11 +134,12 @@ class KoinTagWriter(
     }
 
     private fun writeBindingTag(
+        def: KoinMetaData.Definition,
         binding: KSDeclaration
     ) {
         val name = binding.qualifiedName?.asString()
         if (name !in typeWhiteList) {
-            val tag = TagFactory.getTag(binding)
+            val tag = TagFactory.getTag(def, binding)
             val alreadyGenerated = resolver.isAlreadyExisting(tag)
             if (tag !in alreadyDeclaredTags && !alreadyGenerated) {
                 writeTag(tag)

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinTagWriter.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinTagWriter.kt
@@ -1,4 +1,4 @@
-package org.koin.compiler.verify
+package org.koin.compiler.metadata
 
 import org.koin.compiler.generator.ext.appendText
 import com.google.devtools.ksp.processing.CodeGenerator
@@ -6,9 +6,10 @@ import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSDeclaration
 import org.koin.compiler.generator.ext.getNewFile
-import org.koin.compiler.metadata.KoinMetaData
-import org.koin.compiler.verify.ext.getResolution
-import org.koin.compiler.verify.ext.getResolutionForTag
+import org.koin.compiler.verify.codeGenerationPackage
+import org.koin.compiler.verify.getResolution
+import org.koin.compiler.verify.getResolutionForTag
+import org.koin.compiler.verify.typeWhiteList
 import java.io.OutputStream
 import java.nio.file.Files
 import java.security.DigestOutputStream
@@ -89,7 +90,7 @@ class KoinTagWriter(val codeGenerator: CodeGenerator, val logger: KSPLogger) {
         }
 
         if (mod.alreadyGenerated == false){
-            val className = mod.getTagName()
+            val className = TagFactory.getTagName(mod)
             if (className !in alreadyDeclared) {
                 writeTagLine(className, fileStream, alreadyDeclared)
             }
@@ -115,7 +116,7 @@ class KoinTagWriter(val codeGenerator: CodeGenerator, val logger: KSPLogger) {
         }
 
         if (!def.isExpect && def.alreadyGenerated == false){
-            val className = def.getTagName()
+            val className = TagFactory.getTagName(def)
             if (className !in alreadyDeclared) {
                 writeTagLine(className, fileStream, alreadyDeclared)
             }
@@ -129,10 +130,10 @@ class KoinTagWriter(val codeGenerator: CodeGenerator, val logger: KSPLogger) {
     ) {
         binding.qualifiedName?.asString()?.let { name ->
             if (name !in typeWhiteList) {
-                binding.qualifiedNameCamelCase()?.let { className ->
-                    val alreadyGenerated = resolver.getResolutionForTag(className) != null
-                    if (className !in alreadyDeclared && !alreadyGenerated) {
-                        writeTagLine(className, fileStream, alreadyDeclared)
+                TagFactory.getTagName(binding).let { tagName ->
+                    val alreadyGenerated = resolver.getResolutionForTag(tagName) != null
+                    if (tagName !in alreadyDeclared && !alreadyGenerated) {
+                        writeTagLine(tagName, fileStream, alreadyDeclared)
                     }
                 }
             }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinTagWriter.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinTagWriter.kt
@@ -6,6 +6,7 @@ import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSDeclaration
 import org.koin.compiler.generator.ext.getNewFile
+import org.koin.compiler.resolver.isAlreadyExisting
 import org.koin.compiler.verify.*
 import org.koin.compiler.verify.typeWhiteList
 import java.io.OutputStream

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/MetaAnnotationFactory.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/MetaAnnotationFactory.kt
@@ -1,18 +1,33 @@
 package org.koin.compiler.metadata
 
+import org.koin.meta.annotations.MetaDefinition
 import org.koin.meta.annotations.MetaModule
 
 object MetaAnnotationFactory {
+    private val metaModule = MetaModule::class.simpleName!!
+    private val metaDefinition = MetaDefinition::class.simpleName!!
 
     fun generate(module: KoinMetaData.Module): String {
-        val annotation = MetaModule::class.simpleName!!
         val fullpath = module.packageName + "." + module.name
         val includesTags = if (module.includes?.isNotEmpty() == true) {
-            module.includes.joinToString(",", prefix = "\"", postfix = "\"") { TagFactory.getTag(it) }
+            module.includes.joinToString("\",\"", prefix = "\"", postfix = "\"") { TAG_PREFIX+TagFactory.getTag(it) }
         } else null
         val includesString = includesTags?.let { ", includes=[$it]" } ?: ""
         return """
-            @$annotation("$fullpath"$includesString)
+            @$metaModule("$fullpath"$includesString)
+        """.trimIndent()
+    }
+
+    fun generate(def: KoinMetaData.Definition): String {
+        val fullpath = def.packageName + "." + def.label
+        val deps = def.parameters.filterIsInstance<KoinMetaData.DefinitionParameter.Dependency>()
+
+        val depsTags = if (deps.isNotEmpty()) {
+            deps.joinToString("\",\"", prefix = "\"", postfix = "\"") { TAG_PREFIX+TagFactory.getTag(it) }
+        } else null
+        val depsString = depsTags?.let { ", dependencies=[$it]" } ?: ""
+        return """
+            @$metaDefinition("$fullpath"$depsString)
         """.trimIndent()
     }
 }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/MetaAnnotationFactory.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/MetaAnnotationFactory.kt
@@ -46,8 +46,10 @@ object MetaAnnotationFactory {
 
         val depsString = depsTags?.let { ", dependencies=[$it]" } ?: ""
 
+        val scopeDef = if (def.isScoped()) def.scope?.getTagValue()?.camelCase() else null
+        val scopeString = scopeDef?.let { ", scope=\"$it\"" } ?: ""
         return """
-            @$metaDefinition("$fullpath"$depsString)
+            @$metaDefinition("$fullpath"$depsString$scopeString)
         """.trimIndent()
     }
 

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/MetaAnnotationFactory.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/MetaAnnotationFactory.kt
@@ -1,4 +1,18 @@
 package org.koin.compiler.metadata
 
+import org.koin.meta.annotations.MetaModule
+
 object MetaAnnotationFactory {
+
+    fun generate(module: KoinMetaData.Module): String {
+        val annotation = MetaModule::class.simpleName!!
+        val fullpath = module.packageName + "." + module.name
+        val includesTags = if (module.includes?.isNotEmpty() == true) {
+            module.includes.joinToString(",", prefix = "\"", postfix = "\"") { TagFactory.getTag(it) }
+        } else null
+        val includesString = includesTags?.let { ", includes=[$it]" } ?: ""
+        return """
+            @$annotation("$fullpath"$includesString)
+        """.trimIndent()
+    }
 }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/MetaAnnotationFactory.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/MetaAnnotationFactory.kt
@@ -1,0 +1,4 @@
+package org.koin.compiler.metadata
+
+object MetaAnnotationFactory {
+}

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/MetaAnnotationFactory.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/MetaAnnotationFactory.kt
@@ -10,7 +10,7 @@ object MetaAnnotationFactory {
     fun generate(module: KoinMetaData.Module): String {
         val fullpath = module.packageName + "." + module.name
         val includesTags = if (module.includes?.isNotEmpty() == true) {
-            module.includes.joinToString("\",\"", prefix = "\"", postfix = "\"") { TAG_PREFIX+TagFactory.getTag(it) }
+            module.includes.joinToString("\",\"", prefix = "\"", postfix = "\"") { TagFactory.getTag(it) }
         } else null
         val includesString = includesTags?.let { ", includes=[$it]" } ?: ""
         return """
@@ -23,7 +23,7 @@ object MetaAnnotationFactory {
         val deps = def.parameters.filterIsInstance<KoinMetaData.DefinitionParameter.Dependency>()
 
         val depsTags = if (deps.isNotEmpty()) {
-            deps.joinToString("\",\"", prefix = "\"", postfix = "\"") { TAG_PREFIX+TagFactory.getTag(it) }
+            deps.joinToString("\",\"", prefix = "\"", postfix = "\"") { TagFactory.getTag(it) }
         } else null
         val depsString = depsTags?.let { ", dependencies=[$it]" } ?: ""
         return """

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/MetaAnnotationFactory.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/MetaAnnotationFactory.kt
@@ -23,7 +23,9 @@ object MetaAnnotationFactory {
         val deps = def.parameters.filterIsInstance<KoinMetaData.DefinitionParameter.Dependency>()
 
         val depsTags = if (deps.isNotEmpty()) {
-            deps.joinToString("\",\"", prefix = "\"", postfix = "\"") { TagFactory.getTag(it) }
+            deps
+                .filter { !it.alreadyProvided }
+                .joinToString("\",\"", prefix = "\"", postfix = "\"") { TagFactory.getTag(it) }
         } else null
         val depsString = depsTags?.let { ", dependencies=[$it]" } ?: ""
         return """

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/MetaAnnotationFactory.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/MetaAnnotationFactory.kt
@@ -1,18 +1,22 @@
 package org.koin.compiler.metadata
 
+import org.koin.compiler.verify.typeWhiteList
 import org.koin.meta.annotations.MetaDefinition
 import org.koin.meta.annotations.MetaModule
 
 object MetaAnnotationFactory {
     private val metaModule = MetaModule::class.simpleName!!
     private val metaDefinition = MetaDefinition::class.simpleName!!
+    private val whiteListTags = typeWhiteList.map { TagFactory.getTagFromFullPath(it) }
 
     fun generate(module: KoinMetaData.Module): String {
         val fullpath = module.packageName + "." + module.name
+
         val includesTags = if (module.includes?.isNotEmpty() == true) {
             module.includes.joinToString("\",\"", prefix = "\"", postfix = "\"") { TagFactory.getTag(it) }
         } else null
         val includesString = includesTags?.let { ", includes=[$it]" } ?: ""
+
         return """
             @$metaModule("$fullpath"$includesString)
         """.trimIndent()
@@ -20,14 +24,21 @@ object MetaAnnotationFactory {
 
     fun generate(def: KoinMetaData.Definition): String {
         val fullpath = def.packageName + "." + def.label
-        val deps = def.parameters.filterIsInstance<KoinMetaData.DefinitionParameter.Dependency>()
+        val dependencies = def.parameters.filterIsInstance<KoinMetaData.DefinitionParameter.Dependency>()
 
-        val depsTags = if (deps.isNotEmpty()) {
-            deps
-                .filter { !it.alreadyProvided }
-                .joinToString("\",\"", prefix = "\"", postfix = "\"") { TagFactory.getTag(it) }
-        } else null
+        val cleanedDependencies = dependencies
+            .filter { !it.alreadyProvided && !it.hasDefault && !it.isNullable }
+            .map { TagFactory.getTag(it) }
+            .filter { it !in whiteListTags }
+
+        val depsTags = if (cleanedDependencies.isNotEmpty()) cleanedDependencies.joinToString(
+            "\",\"",
+            prefix = "\"",
+            postfix = "\""
+        ) else null
+
         val depsString = depsTags?.let { ", dependencies=[$it]" } ?: ""
+
         return """
             @$metaDefinition("$fullpath"$depsString)
         """.trimIndent()

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/TagFactory.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/TagFactory.kt
@@ -4,10 +4,13 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSDeclaration
 import org.koin.compiler.scanner.ext.filterForbiddenKeywords
 import org.koin.compiler.scanner.ext.getPackageName
+import org.koin.compiler.verify.DefinitionVerification
 import org.koin.compiler.verify.qualifiedNameCamelCase
 import java.util.*
 
 const val KOIN_TAG_SEPARATOR = "_"
+private const val QUALIFIER_SYMBOL = "Q_"
+private const val SCOPE_SYMBOL = "S_"
 
 object TagFactory {
 
@@ -35,24 +38,24 @@ object TagFactory {
         return with(definition) {
             listOfNotNull(
                 clazz.qualifiedNameCamelCase()?.clearPackageSymbols() ?: "",
-                qualifier?.let { "Q_${escapeTagClass(it)}" },
-                scope?.getTagValue()?.camelCase()?.let { "S_$it" },
+                qualifier?.let { "$QUALIFIER_SYMBOL${escapeTagClass(it)}" },
+                scope?.getTagValue()?.camelCase()?.let { "$SCOPE_SYMBOL$it" },
                 if (isExpect) "Expect" else null,
                 if (isActual) "Actual" else null
             ).joinToString(separator = KOIN_TAG_SEPARATOR)
         }
     }
 
-    fun getTag(clazz: KSDeclaration): String {
-        return clazz.qualifiedNameCamelCase() ?: ""
-    }
+    fun getTag(classTag: String, dv: DefinitionVerification) =  "$classTag$KOIN_TAG_SEPARATOR$SCOPE_SYMBOL${dv.scope}"
+
+    fun getTag(clazz: KSDeclaration): String = clazz.qualifiedNameCamelCase() ?: ""
 
     fun getTag(definition: KoinMetaData.Definition): String {
         return with(definition) {
             listOfNotNull(
                 packageName.camelCase() + label.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() },
-                qualifier?.let { "Q_${escapeTagClass(it)}" },
-                scope?.getTagValue()?.camelCase()?.let { "S_$it" },
+                qualifier?.let { "$QUALIFIER_SYMBOL${escapeTagClass(it)}" },
+                scope?.getTagValue()?.camelCase()?.let { "$SCOPE_SYMBOL$it" },
                 if (isExpect) "Expect" else null,
                 if (isActual) "Actual" else null
             ).joinToString(separator = KOIN_TAG_SEPARATOR)
@@ -71,8 +74,7 @@ object TagFactory {
                 packageName.clearPackageSymbols().camelCase() + className.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
             listOfNotNull(
                 packageNameConsolidated,
-                qualifier?.let { "Q_${escapeTagClass(it)}" },
-//                scopeId?.let { "S_$it" },
+                qualifier?.let { "$QUALIFIER_SYMBOL${escapeTagClass(it)}" },
                 if (isExpect) "Expect" else null,
                 if (isActual) "Actual" else null
             ).joinToString(separator = KOIN_TAG_SEPARATOR)

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/TagFactory.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/TagFactory.kt
@@ -73,4 +73,8 @@ object TagFactory {
             ).joinToString(separator = KOIN_TAG_SEPARATOR)
         }
     }
+
+    fun getTagFromFullPath(path: String) : String {
+        return path.split(".").joinToString(separator = "") { it.capitalize() }
+    }
 }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/TagFactory.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/TagFactory.kt
@@ -1,0 +1,49 @@
+package org.koin.compiler.metadata
+
+import com.google.devtools.ksp.symbol.KSDeclaration
+import org.koin.compiler.verify.qualifiedNameCamelCase
+import java.util.*
+
+const val KOIN_TAG_SEPARATOR = ""
+
+object TagFactory {
+
+    fun getTagName(module: KoinMetaData.Module): String {
+        return with(module) {
+            listOfNotNull(
+                packageName.camelCase(),
+                name,
+                if (isExpect) "Expect" else null,
+                if (isActual) "Actual" else null
+            ).joinToString(separator = KOIN_TAG_SEPARATOR)
+        }
+    }
+
+    fun getTagName(module: KoinMetaData.ModuleInclude): String {
+        return with(module) {
+            listOfNotNull(
+                packageName.camelCase(),
+                className.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() },
+                if (isExpect) "Expect" else null,
+                if (isActual) "Actual" else null
+            ).joinToString(separator = KOIN_TAG_SEPARATOR)
+        }
+    }
+
+    fun getTagName(clazz: KSDeclaration): String {
+        return clazz.qualifiedNameCamelCase() ?: ""
+    }
+
+    fun getTagName(definition: KoinMetaData.Definition): String {
+        return with(definition) {
+            listOfNotNull(
+                packageName.camelCase(),
+                label.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() },
+                qualifier?.let { "Q_$it" },
+                scope?.getTagValue()?.camelCase()?.let { "S_$it" },
+                if (isExpect) "Expect" else null,
+                if (isActual) "Actual" else null
+            ).joinToString(separator = KOIN_TAG_SEPARATOR)
+        }
+    }
+}

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/TagFactory.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/TagFactory.kt
@@ -32,7 +32,6 @@ object TagFactory {
     }
 
     fun getTag(definition: KoinMetaData.Definition, clazz: KSDeclaration): String {
-//        return clazz.qualifiedNameCamelCase() ?: ""
         return with(definition) {
             listOfNotNull(
                 clazz.qualifiedNameCamelCase() ?: "",
@@ -42,6 +41,10 @@ object TagFactory {
                 if (isActual) "Actual" else null
             ).joinToString(separator = KOIN_TAG_SEPARATOR)
         }
+    }
+
+    fun getTag(clazz: KSDeclaration): String {
+        return clazz.qualifiedNameCamelCase() ?: ""
     }
 
     fun getTag(definition: KoinMetaData.Definition): String {

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/TagFactory.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/TagFactory.kt
@@ -8,7 +8,7 @@ const val KOIN_TAG_SEPARATOR = ""
 
 object TagFactory {
 
-    fun getTagName(module: KoinMetaData.Module): String {
+    fun getTag(module: KoinMetaData.Module): String {
         return with(module) {
             listOfNotNull(
                 packageName.camelCase(),
@@ -19,7 +19,7 @@ object TagFactory {
         }
     }
 
-    fun getTagName(module: KoinMetaData.ModuleInclude): String {
+    fun getTag(module: KoinMetaData.ModuleInclude): String {
         return with(module) {
             listOfNotNull(
                 packageName.camelCase(),
@@ -30,11 +30,11 @@ object TagFactory {
         }
     }
 
-    fun getTagName(clazz: KSDeclaration): String {
+    fun getTag(clazz: KSDeclaration): String {
         return clazz.qualifiedNameCamelCase() ?: ""
     }
 
-    fun getTagName(definition: KoinMetaData.Definition): String {
+    fun getTag(definition: KoinMetaData.Definition): String {
         return with(definition) {
             listOfNotNull(
                 packageName.camelCase(),

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/TagFactory.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/TagFactory.kt
@@ -1,6 +1,9 @@
 package org.koin.compiler.metadata
 
+import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSDeclaration
+import org.koin.compiler.scanner.ext.filterForbiddenKeywords
+import org.koin.compiler.scanner.ext.getPackageName
 import org.koin.compiler.verify.qualifiedNameCamelCase
 import java.util.*
 
@@ -41,6 +44,25 @@ object TagFactory {
                 label.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() },
                 qualifier?.let { "Q_$it" },
                 scope?.getTagValue()?.camelCase()?.let { "S_$it" },
+                if (isExpect) "Expect" else null,
+                if (isActual) "Actual" else null
+            ).joinToString(separator = KOIN_TAG_SEPARATOR)
+        }
+    }
+
+    fun getTag(dep: KoinMetaData.DefinitionParameter.Dependency): String {
+        return with(dep) {
+            val ksClassDeclaration = (dep.type.declaration as KSClassDeclaration)
+            val packageName = ksClassDeclaration.getPackageName().filterForbiddenKeywords()
+            val className = ksClassDeclaration.simpleName.asString()
+            val isExpect = ksClassDeclaration.isExpect
+            val isActual = ksClassDeclaration.isActual
+
+            listOfNotNull(
+                packageName.camelCase(),
+                className.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() },
+                qualifier?.let { "Q_$it" },
+                scopeId?.let { "S_$it" },
                 if (isExpect) "Expect" else null,
                 if (isActual) "Actual" else null
             ).joinToString(separator = KOIN_TAG_SEPARATOR)

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/TagFactory.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/TagFactory.kt
@@ -34,8 +34,8 @@ object TagFactory {
     fun getTag(definition: KoinMetaData.Definition, clazz: KSDeclaration): String {
         return with(definition) {
             listOfNotNull(
-                clazz.qualifiedNameCamelCase() ?: "",
-                qualifier?.let { "Q_$it" },
+                clazz.qualifiedNameCamelCase()?.clearPackageSymbols() ?: "",
+                qualifier?.let { "Q_${escapeTagClass(it)}" },
                 scope?.getTagValue()?.camelCase()?.let { "S_$it" },
                 if (isExpect) "Expect" else null,
                 if (isActual) "Actual" else null
@@ -51,7 +51,7 @@ object TagFactory {
         return with(definition) {
             listOfNotNull(
                 packageName.camelCase() + label.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() },
-                qualifier?.let { "Q_$it" },
+                qualifier?.let { "Q_${escapeTagClass(it)}" },
                 scope?.getTagValue()?.camelCase()?.let { "S_$it" },
                 if (isExpect) "Expect" else null,
                 if (isActual) "Actual" else null
@@ -67,13 +67,24 @@ object TagFactory {
             val isExpect = ksClassDeclaration.isExpect
             val isActual = ksClassDeclaration.isActual
 
+            val packageNameConsolidated =
+                packageName.clearPackageSymbols().camelCase() + className.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
             listOfNotNull(
-                packageName.camelCase() + className.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() },
-                qualifier?.let { "Q_$it" },
-                scopeId?.let { "S_$it" },
+                packageNameConsolidated,
+                qualifier?.let { "Q_${escapeTagClass(it)}" },
+//                scopeId?.let { "S_$it" },
                 if (isExpect) "Expect" else null,
                 if (isActual) "Actual" else null
             ).joinToString(separator = KOIN_TAG_SEPARATOR)
+        }
+    }
+
+    internal fun String.clearPackageSymbols() = replace("`","").replace("'","")
+
+    private fun escapeTagClass(qualifier : String) : String {
+        return if (!qualifier.contains(".")) qualifier
+        else {
+            qualifier.split(".").joinToString("") { it.capitalize() }
         }
     }
 

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/TagFactory.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/TagFactory.kt
@@ -31,8 +31,17 @@ object TagFactory {
         }
     }
 
-    fun getTag(clazz: KSDeclaration): String {
-        return clazz.qualifiedNameCamelCase() ?: ""
+    fun getTag(definition: KoinMetaData.Definition, clazz: KSDeclaration): String {
+//        return clazz.qualifiedNameCamelCase() ?: ""
+        return with(definition) {
+            listOfNotNull(
+                clazz.qualifiedNameCamelCase() ?: "",
+                qualifier?.let { "Q_$it" },
+                scope?.getTagValue()?.camelCase()?.let { "S_$it" },
+                if (isExpect) "Expect" else null,
+                if (isActual) "Actual" else null
+            ).joinToString(separator = KOIN_TAG_SEPARATOR)
+        }
     }
 
     fun getTag(definition: KoinMetaData.Definition): String {

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/TagFactory.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/TagFactory.kt
@@ -7,15 +7,14 @@ import org.koin.compiler.scanner.ext.getPackageName
 import org.koin.compiler.verify.qualifiedNameCamelCase
 import java.util.*
 
-const val KOIN_TAG_SEPARATOR = ""
+const val KOIN_TAG_SEPARATOR = "_"
 
 object TagFactory {
 
     fun getTag(module: KoinMetaData.Module): String {
         return with(module) {
             listOfNotNull(
-                packageName.camelCase(),
-                name,
+                packageName.camelCase() + name,
                 if (isExpect) "Expect" else null,
                 if (isActual) "Actual" else null
             ).joinToString(separator = KOIN_TAG_SEPARATOR)
@@ -25,8 +24,7 @@ object TagFactory {
     fun getTag(module: KoinMetaData.ModuleInclude): String {
         return with(module) {
             listOfNotNull(
-                packageName.camelCase(),
-                className.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() },
+                packageName.camelCase() + className.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() },
                 if (isExpect) "Expect" else null,
                 if (isActual) "Actual" else null
             ).joinToString(separator = KOIN_TAG_SEPARATOR)
@@ -40,8 +38,7 @@ object TagFactory {
     fun getTag(definition: KoinMetaData.Definition): String {
         return with(definition) {
             listOfNotNull(
-                packageName.camelCase(),
-                label.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() },
+                packageName.camelCase() + label.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() },
                 qualifier?.let { "Q_$it" },
                 scope?.getTagValue()?.camelCase()?.let { "S_$it" },
                 if (isExpect) "Expect" else null,
@@ -59,8 +56,7 @@ object TagFactory {
             val isActual = ksClassDeclaration.isActual
 
             listOfNotNull(
-                packageName.camelCase(),
-                className.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() },
+                packageName.camelCase() + className.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() },
                 qualifier?.let { "Q_$it" },
                 scopeId?.let { "S_$it" },
                 if (isExpect) "Expect" else null,

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/resolver/ResolverExt.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/resolver/ResolverExt.kt
@@ -1,10 +1,11 @@
-package org.koin.compiler.verify
+package org.koin.compiler.resolver
 
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSDeclaration
 import org.koin.compiler.metadata.KoinMetaData
 import org.koin.compiler.metadata.TagFactory
 import org.koin.compiler.metadata.TAG_PREFIX
+import org.koin.compiler.verify.codeGenerationPackage
 
 fun Resolver.isAlreadyExisting(mod : KoinMetaData.Module) : Boolean {
     return getResolution(mod) != null

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/ClassComponentScanner.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/ClassComponentScanner.kt
@@ -56,24 +56,23 @@ class ClassComponentScanner(
         val ctorParams = ksClassDeclaration.primaryConstructor?.parameters?.getParameters()
 
         val isExpect = ksClassDeclaration.isExpect
-//        val isActual = ksClassDeclaration.isActual
-//        LOGGER.info("definition - $packageName $className - isExpect:$isExpect isActual:$isActual")
+        val isActual = ksClassDeclaration.isActual
 
         return when (annotationName) {
             SINGLE.annotationName -> {
-                createSingleDefinition(annotation, packageName, qualifier, className, ctorParams, allBindings, isExpect)
+                createSingleDefinition(annotation, packageName, qualifier, className, ctorParams, allBindings, isExpect, isActual = isActual)
             }
             SINGLETON.annotationName -> {
-                createSingleDefinition(annotation, packageName, qualifier, className, ctorParams, allBindings, isExpect)
+                createSingleDefinition(annotation, packageName, qualifier, className, ctorParams, allBindings, isExpect, isActual = isActual)
             }
             FACTORY.annotationName -> {
-                createClassDefinition(FACTORY,packageName, qualifier, className, ctorParams, allBindings, isExpect = isExpect)
+                createClassDefinition(FACTORY,packageName, qualifier, className, ctorParams, allBindings, isExpect = isExpect, isActual = isActual)
             }
             KOIN_VIEWMODEL_ANDROID.annotationName -> {
-                createClassDefinition(KOIN_VIEWMODEL_ANDROID,packageName, qualifier, className, ctorParams, allBindings, isExpect = isExpect)
+                createClassDefinition(KOIN_VIEWMODEL_ANDROID,packageName, qualifier, className, ctorParams, allBindings, isExpect = isExpect, isActual = isActual)
             }
             KOIN_WORKER.annotationName -> {
-                createClassDefinition(KOIN_WORKER,packageName, qualifier, className, ctorParams, allBindings, isExpect = isExpect)
+                createClassDefinition(KOIN_WORKER,packageName, qualifier, className, ctorParams, allBindings, isExpect = isExpect, isActual = isActual)
             }
             SCOPE.annotationName -> {
                 val scopeData : KoinMetaData.Scope = annotation.arguments.getScope()
@@ -81,7 +80,7 @@ class ClassComponentScanner(
                 val extraAnnotation = annotations[extraAnnotationDefinition?.annotationName]
                 val extraDeclaredBindings = extraAnnotation?.let { declaredBindings(it) }
                 val extraScopeBindings = if(extraDeclaredBindings?.hasDefaultUnitValue() == false) extraDeclaredBindings else allBindings
-                createClassDefinition(extraAnnotationDefinition ?: SCOPE,packageName, qualifier, className, ctorParams, extraScopeBindings,scope = scopeData, isExpect = isExpect)
+                createClassDefinition(extraAnnotationDefinition ?: SCOPE,packageName, qualifier, className, ctorParams, extraScopeBindings,scope = scopeData, isExpect = isExpect, isActual = isActual)
             }
             else -> error("Unknown annotation type: $annotationName")
         }
@@ -95,10 +94,11 @@ class ClassComponentScanner(
         ctorParams: List<KoinMetaData.DefinitionParameter>?,
         allBindings: List<KSDeclaration>,
         isExpect : Boolean,
+        isActual : Boolean
     ): KoinMetaData.Definition.ClassDefinition {
         val createdAtStart: Boolean =
             annotation.arguments.firstOrNull { it.name?.asString() == "createdAtStart" }?.value as Boolean? ?: false
-        return createClassDefinition(SINGLE, packageName, qualifier, className, ctorParams, allBindings, isCreatedAtStart = createdAtStart, isExpect= isExpect)
+        return createClassDefinition(SINGLE, packageName, qualifier, className, ctorParams, allBindings, isCreatedAtStart = createdAtStart, isExpect= isExpect, isActual = isActual)
     }
 
     private fun createClassDefinition(
@@ -111,6 +111,7 @@ class ClassComponentScanner(
         isCreatedAtStart : Boolean? = null,
         scope: KoinMetaData.Scope? = null,
         isExpect : Boolean,
+        isActual : Boolean
     ): KoinMetaData.Definition.ClassDefinition {
         return KoinMetaData.Definition.ClassDefinition(
             packageName = packageName,
@@ -121,7 +122,8 @@ class ClassComponentScanner(
             bindings = allBindings,
             keyword = keyword,
             scope = scope,
-            isExpect = isExpect
+            isExpect = isExpect,
+            isActual = isActual
         )
     }
 }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/FunctionScanner.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/FunctionScanner.kt
@@ -45,27 +45,28 @@ abstract class FunctionScanner(
         val allBindings: List<KSDeclaration> =  returnedType?.let { foundBindings + it } ?: foundBindings
         val functionParameters = ksFunctionDeclaration.parameters.getParameters()
         val isExpect = ksFunctionDeclaration.isExpect
+        val isActual = ksFunctionDeclaration.isActual
 
         return when (annotationName) {
             SINGLE.annotationName -> {
-                createSingleDefinition(annotation, packageName, qualifier, functionName, functionParameters, allBindings, isExpect)
+                createSingleDefinition(annotation, packageName, qualifier, functionName, functionParameters, allBindings, isExpect, isActual = isActual)
             }
             SINGLETON.annotationName -> {
-                createSingleDefinition(annotation, packageName, qualifier, functionName, functionParameters, allBindings, isExpect)
+                createSingleDefinition(annotation, packageName, qualifier, functionName, functionParameters, allBindings, isExpect, isActual = isActual)
             }
             FACTORY.annotationName -> {
-                createDefinition(FACTORY,packageName,qualifier,functionName,functionParameters,allBindings, isExpect = isExpect)
+                createDefinition(FACTORY,packageName,qualifier,functionName,functionParameters,allBindings, isExpect = isExpect, isActual = isActual)
             }
             KOIN_VIEWMODEL_ANDROID.annotationName -> {
-                createDefinition(KOIN_VIEWMODEL_ANDROID,packageName,qualifier,functionName,functionParameters,allBindings, isExpect = isExpect)
+                createDefinition(KOIN_VIEWMODEL_ANDROID,packageName,qualifier,functionName,functionParameters,allBindings, isExpect = isExpect, isActual = isActual)
             }
             KOIN_WORKER.annotationName -> {
-                createDefinition(KOIN_WORKER,packageName,qualifier,functionName,functionParameters,allBindings, isExpect = isExpect)
+                createDefinition(KOIN_WORKER,packageName,qualifier,functionName,functionParameters,allBindings, isExpect = isExpect, isActual = isActual)
             }
             SCOPE.annotationName -> {
                 val scopeData : KoinMetaData.Scope = annotation.arguments.getScope()
                 val extraAnnotation = getExtraScopeAnnotation(annotations)
-                createDefinition(extraAnnotation ?: SCOPE,packageName,qualifier,functionName,functionParameters,allBindings,scope = scopeData, isExpect = isExpect)
+                createDefinition(extraAnnotation ?: SCOPE,packageName,qualifier,functionName,functionParameters,allBindings,scope = scopeData, isExpect = isExpect, isActual = isActual)
             }
             else -> null
         }
@@ -78,7 +79,8 @@ abstract class FunctionScanner(
         functionName: String,
         functionParameters: List<KoinMetaData.DefinitionParameter>,
         allBindings: List<KSDeclaration>,
-        isExpect : Boolean
+        isExpect : Boolean,
+        isActual : Boolean
     ): KoinMetaData.Definition.FunctionDefinition {
         val createdAtStart: Boolean =
             annotation.arguments.firstOrNull { it.name?.asString() == "createdAtStart" }?.value as Boolean?
@@ -91,7 +93,8 @@ abstract class FunctionScanner(
             functionParameters,
             allBindings,
             isCreatedAtStart = createdAtStart,
-            isExpect = isExpect
+            isExpect = isExpect,
+            isActual = isActual
         )
     }
 
@@ -104,7 +107,8 @@ abstract class FunctionScanner(
         allBindings: List<KSDeclaration>,
         isCreatedAtStart : Boolean? = null,
         scope: KoinMetaData.Scope? = null,
-        isExpect : Boolean
+        isExpect : Boolean,
+        isActual : Boolean
     ): KoinMetaData.Definition.FunctionDefinition {
         return KoinMetaData.Definition.FunctionDefinition(
             packageName = packageName,
@@ -115,7 +119,8 @@ abstract class FunctionScanner(
             bindings = allBindings,
             keyword = keyword,
             scope = scope,
-            isExpect = isExpect
+            isExpect = isExpect,
+            isActual = isActual
         ).apply { isClassFunction = isModuleFunction }
     }
 

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/KoinMetaDataScanner.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/KoinMetaDataScanner.kt
@@ -25,9 +25,9 @@ import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.validate
 import org.koin.compiler.metadata.DEFINITION_ANNOTATION_LIST_TYPES
 import org.koin.compiler.metadata.KoinMetaData
-import org.koin.core.annotation.Definition
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.PropertyValue
+import org.koin.meta.annotations.ExternalDefinition
 
 class KoinMetaDataScanner(
     private val logger: KSPLogger
@@ -232,6 +232,6 @@ class KoinMetaDataScanner(
     }
 
     companion object {
-        private val DEFINITION_ANNOTATION = Definition::class.simpleName
+        private val DEFINITION_ANNOTATION = ExternalDefinition::class.simpleName
     }
 }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/KoinTagMetaDataScanner.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/KoinTagMetaDataScanner.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.koin.compiler.scanner
+
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.validate
+import org.koin.meta.annotations.MetaDefinition
+import org.koin.meta.annotations.MetaModule
+
+class KoinTagMetaDataScanner(
+    private val logger: KSPLogger,
+    private val resolver: Resolver
+) {
+
+    fun findInvalidSymbols(): List<KSAnnotated> {
+        val invalidModuleSymbols = resolver.getMetaModuleSymbols(isValid = false)
+        val invalidDefinitionSymbols = resolver.getMetaDefinitionSymbols(isValid = false)
+
+        val invalidSymbols = invalidModuleSymbols + invalidDefinitionSymbols
+        if (invalidSymbols.isNotEmpty()) {
+            logger.logging("Invalid definition symbols found.")
+            logInvalidEntities(invalidSymbols)
+            return invalidSymbols
+        }
+
+        return emptyList()
+    }
+
+    fun findMetaModules(): List<KSAnnotation> {
+        logger.warn("scan meta modules ...")
+        return resolver.getMetaModuleSymbols(isValid = true).map { it.annotations.first() }
+    }
+
+    fun findMetaDefinitions(): List<KSAnnotation> {
+        logger.warn("scan meta definitions ...")
+        return resolver.getMetaDefinitionSymbols(isValid = true).map { it.annotations.first() }
+    }
+
+    private fun Resolver.getMetaModuleSymbols(isValid : Boolean): List<KSAnnotated> {
+        return this.getSymbolsWithAnnotation(MetaModule::class.qualifiedName!!)
+            .filter { isValid == it.validate() }
+            .toList()
+    }
+
+    private fun Resolver.getMetaDefinitionSymbols(isValid : Boolean): List<KSAnnotated> {
+        return this.getSymbolsWithAnnotation(MetaDefinition::class.qualifiedName!!)
+            .filter { isValid == it.validate() }
+            .toList()
+    }
+
+    private fun logInvalidEntities(classDeclarationList: List<KSAnnotated>) {
+        classDeclarationList.forEach { logger.logging("Invalid entity: $it") }
+    }
+
+}

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/ModuleScanner.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/ModuleScanner.kt
@@ -114,7 +114,7 @@ class ModuleScanner(
     private fun KSDeclaration.mapModuleInclude(): KoinMetaData.ModuleInclude {
         val packageName: String = packageName.asString()
         val className = simpleName.asString()
-        return KoinMetaData.ModuleInclude(packageName, className, isExpect)
+        return KoinMetaData.ModuleInclude(packageName, className, isExpect, isActual)
     }
 }
 

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/ext/KspExt.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/ext/KspExt.kt
@@ -141,6 +141,10 @@ internal fun List<KSValueArgument>.getValueArgument(): String? {
     return firstOrNull { a -> a.name?.asString() == "value" }?.value as? String?
 }
 
+internal fun List<KSValueArgument>.getScopeArgument(): String? {
+    return firstOrNull { a -> a.name?.asString() == "scope" }?.value as? String?
+}
+
 fun KSClassDeclaration.getPackageName() : String = packageName.asString()
 
 val forbiddenKeywords = listOf("in","interface")

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/KoinConfigChecker.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/KoinConfigChecker.kt
@@ -109,13 +109,13 @@ class KoinConfigChecker(val logger: KSPLogger, val resolver: Resolver) {
     }
 
     private fun verifyMetaModule(value: String, includes: ArrayList<String>) {
-        logger.warn("verifyMetaModule: m:$value - i:$includes")
+//        logger.warn("verifyMetaModule: m:$value - i:$includes")
         includes.forEach { i ->
             val exists = resolver.isAlreadyExisting(i)
-            logger.warn("verifyMetaModule: m:$value -> $i = $exists")
-//            if (!exists) {
-//                logger.error("--> Missing Module Definition :'${i}' included in '$value'. Fix your configuration: add @Module annotation on the class.")
-//            }
+//            logger.warn("verifyMetaModule: m:$value -> $i = $exists")
+            if (!exists) {
+                logger.error("--> Missing Module Definition :'${i}' included in '$value'. Fix your configuration: add @Module annotation on the class.")
+            }
         }
     }
 
@@ -129,19 +129,19 @@ class KoinConfigChecker(val logger: KSPLogger, val resolver: Resolver) {
         metaDefinitions
             .mapNotNull(::extractMetaDefinitionValues)
             .forEach { (value,dependencies) ->
-                logger.warn("verifyMetaDefinitions: def:$value - deps:$dependencies")
+//                logger.warn("verifyMetaDefinitions: def:$value - deps:$dependencies")
                 if (!dependencies.isNullOrEmpty()) verifyMetaDefinition(value,dependencies)
             }
     }
 
     private fun verifyMetaDefinition(value: String, dependencies: ArrayList<String>) {
-        logger.warn("verifyMetaDefinition: def:$value - i:$dependencies")
+//        logger.warn("verifyMetaDefinition: def:$value - i:$dependencies")
         dependencies.forEach { i ->
             val exists = resolver.isAlreadyExisting(i)
-            logger.warn("verifyMetaDefinition: def:$value -> $i = $exists")
-//            if (!exists) {
-//                logger.error("--> Missing Definition :'${i}' used by '$value'. Fix your configuration: add @Module annotation on the class.")
-//            }
+            if (!exists) {
+                logger.warn("verifyMetaDefinition: def:$value -> $i = $exists")
+                logger.warn("--> Missing Definition :'${i}' used by '$value'. Fix your configuration: add @Module annotation on the class.")
+            }
         }
     }
 

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/KoinConfigChecker.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/KoinConfigChecker.kt
@@ -20,7 +20,7 @@ import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSDeclaration
 import org.koin.compiler.metadata.KoinMetaData
-import org.koin.compiler.verify.ext.getResolutionForTag
+import org.koin.compiler.metadata.TagFactory
 
 const val codeGenerationPackage = "org.koin.ksp.generated"
 
@@ -35,7 +35,8 @@ class KoinConfigChecker(val codeGenerator: CodeGenerator, val logger: KSPLogger)
     ) {
         val isAlreadyGenerated = codeGenerator.generatedFile.isEmpty()
         val allDefinitions = moduleList.flatMap { it.definitions }
-
+        logger.warn("allDefinitions:${allDefinitions.size}")
+        logger.warn("isAlreadyGenerated:$isAlreadyGenerated")
         if (isAlreadyGenerated) {
             verifyDependencies(allDefinitions, resolver)
         }
@@ -45,6 +46,7 @@ class KoinConfigChecker(val codeGenerator: CodeGenerator, val logger: KSPLogger)
         allDefinitions: List<KoinMetaData.Definition>,
         resolver: Resolver
     ) {
+        logger.warn("allDefinitions:${allDefinitions.size} symbols found")
         allDefinitions.forEach { def ->
             def.parameters
                 .filterIsInstance<KoinMetaData.DefinitionParameter.Dependency>()
@@ -97,7 +99,7 @@ class KoinConfigChecker(val codeGenerator: CodeGenerator, val logger: KSPLogger)
             modules.forEach { m ->
                 val mn = m.packageName + "." + m.name
                 m.includes?.forEach { inc ->
-                    val prop = resolver.getResolutionForTag(inc.getTagName())
+                    val prop = resolver.getResolutionForTag(TagFactory.getTagName(inc))
                     if (prop == null) {
                         logger.error("--> Module Undefined :'${inc.className}' included in '$mn'. Fix your configuration: add @Module annotation on '${inc.className}' class.")
                     }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/KoinConfigChecker.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/KoinConfigChecker.kt
@@ -99,7 +99,7 @@ class KoinConfigChecker(val codeGenerator: CodeGenerator, val logger: KSPLogger)
             modules.forEach { m ->
                 val mn = m.packageName + "." + m.name
                 m.includes?.forEach { inc ->
-                    val prop = resolver.getResolutionForTag(TagFactory.getTagName(inc))
+                    val prop = resolver.getResolutionForTag(TagFactory.getTag(inc))
                     if (prop == null) {
                         logger.error("--> Module Undefined :'${inc.className}' included in '$mn'. Fix your configuration: add @Module annotation on '${inc.className}' class.")
                     }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/KoinConfigChecker.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/KoinConfigChecker.kt
@@ -20,8 +20,10 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSValueArgument
+import org.koin.compiler.metadata.TagFactory.clearPackageSymbols
 import org.koin.compiler.resolver.isAlreadyExisting
 import org.koin.compiler.scanner.ext.getValueArgument
+import org.koin.ext.clearQuotes
 
 const val codeGenerationPackage = "org.koin.ksp.generated"
 
@@ -63,9 +65,9 @@ class KoinConfigChecker(val logger: KSPLogger, val resolver: Resolver) {
 
     private fun verifyMetaDefinition(value: String, dependencies: ArrayList<String>) {
         dependencies.forEach { i ->
-            val exists = resolver.isAlreadyExisting(i)
+            val exists = resolver.isAlreadyExisting(i.clearPackageSymbols())
             if (!exists) {
-                logger.error("--> Missing Definition :'${i}' used by '$value'. Fix your configuration: add @Module annotation on the class.")
+                logger.error("--> Missing Definition :'${i}' used by '$value'. Fix your configuration: add definition annotation on the class.")
             }
         }
     }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/KoinConfigChecker.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/KoinConfigChecker.kt
@@ -20,7 +20,6 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSValueArgument
-import org.koin.compiler.resolver.getResolutionForTag
 import org.koin.compiler.resolver.isAlreadyExisting
 import org.koin.compiler.scanner.ext.getValueArgument
 
@@ -31,75 +30,6 @@ const val codeGenerationPackage = "org.koin.ksp.generated"
  */
 class KoinConfigChecker(val logger: KSPLogger, val resolver: Resolver) {
 
-//    fun verify(allModules: List<KoinMetaData.Module>) {
-//        verifyDefinitionDeclarations(allModules)
-//        verifyModuleIncludes(allModules)
-//    }
-
-//    private fun verifyDefinitionDeclarations(moduleList: List<KoinMetaData.Module>) {
-//        val allDefinitions = moduleList.flatMap { it.definitions }
-//        verifyDependencies(allDefinitions)
-//    }
-
-//    private fun verifyDependencies(
-//        allDefinitions: List<KoinMetaData.Definition>
-//    ) {
-//        allDefinitions.forEach { def ->
-//            def.parameters
-//                .filterIsInstance<KoinMetaData.DefinitionParameter.Dependency>()
-//                .forEach { param ->
-//                    checkDependency(param, def)
-//                    //TODO Check Cycle
-//                }
-//        }
-//    }
-
-//    private fun checkDependency(
-//        param: KoinMetaData.DefinitionParameter.Dependency,
-//        def: KoinMetaData.Definition
-//    ) {
-//        if (!param.hasDefault && !param.isNullable && !param.alreadyProvided) {
-//            checkDependencyIsDefined(param, def)
-//        }
-//    }
-
-
-//    private fun checkDependencyIsDefined(
-//        dependencyToCheck: KoinMetaData.DefinitionParameter.Dependency,
-//        definition: KoinMetaData.Definition,
-//    ) {
-//        val label = definition.label
-//        val scope = (definition.scope as? KoinMetaData.Scope.ClassScope)?.type?.qualifiedName?.asString()
-//        var targetTypeToCheck: KSDeclaration = dependencyToCheck.type.declaration
-//
-//        if (targetTypeToCheck.simpleName.asString() == "List" || targetTypeToCheck.simpleName.asString() == "Lazy") {
-//            targetTypeToCheck =
-//                dependencyToCheck.type.arguments.firstOrNull()?.type?.resolve()?.declaration ?: targetTypeToCheck
-//        }
-//
-//        val parameterFullName = targetTypeToCheck.qualifiedName?.asString()
-//        if (parameterFullName !in typeWhiteList && parameterFullName != null) {
-//            val cn = targetTypeToCheck.qualifiedNameCamelCase()
-//            val resolution = resolver.getResolutionForTag(cn)
-//            val isNotScopeType = scope != parameterFullName
-//            if (resolution == null && isNotScopeType) {
-//                logger.error("--> Missing Definition type '$parameterFullName' for '${definition.packageName}.$label'. Fix your configuration to define type '${targetTypeToCheck.simpleName.asString()}'.")
-//            }
-//        }
-//    }
-
-//    fun verifyModuleIncludes(modules: List<KoinMetaData.Module>) {
-//        modules.forEach { m ->
-//            val mn = m.packageName + "." + m.name
-//            m.includes?.forEach { inc ->
-//                val prop = resolver.getResolutionForTag(TagFactory.getTag(inc))
-//                if (prop == null) {
-//                    logger.error("--> Module Undefined :'${inc.className}' included in '$mn'. Fix your configuration: add @Module annotation on '${inc.className}' class.")
-//                }
-//            }
-//        }
-//    }
-
     fun verifyMetaModules(metaModules: List<KSAnnotation>) {
         metaModules
             .mapNotNull(::extractMetaModuleValues)
@@ -109,10 +39,8 @@ class KoinConfigChecker(val logger: KSPLogger, val resolver: Resolver) {
     }
 
     private fun verifyMetaModule(value: String, includes: ArrayList<String>) {
-//        logger.warn("verifyMetaModule: m:$value - i:$includes")
         includes.forEach { i ->
             val exists = resolver.isAlreadyExisting(i)
-//            logger.warn("verifyMetaModule: m:$value -> $i = $exists")
             if (!exists) {
                 logger.error("--> Missing Module Definition :'${i}' included in '$value'. Fix your configuration: add @Module annotation on the class.")
             }
@@ -129,18 +57,15 @@ class KoinConfigChecker(val logger: KSPLogger, val resolver: Resolver) {
         metaDefinitions
             .mapNotNull(::extractMetaDefinitionValues)
             .forEach { (value,dependencies) ->
-//                logger.warn("verifyMetaDefinitions: def:$value - deps:$dependencies")
                 if (!dependencies.isNullOrEmpty()) verifyMetaDefinition(value,dependencies)
             }
     }
 
     private fun verifyMetaDefinition(value: String, dependencies: ArrayList<String>) {
-//        logger.warn("verifyMetaDefinition: def:$value - i:$dependencies")
         dependencies.forEach { i ->
             val exists = resolver.isAlreadyExisting(i)
             if (!exists) {
-                logger.warn("verifyMetaDefinition: def:$value -> $i = $exists")
-                logger.warn("--> Missing Definition :'${i}' used by '$value'. Fix your configuration: add @Module annotation on the class.")
+                logger.error("--> Missing Definition :'${i}' used by '$value'. Fix your configuration: add @Module annotation on the class.")
             }
         }
     }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/KoinConfigChecker.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/KoinConfigChecker.kt
@@ -17,10 +17,12 @@ package org.koin.compiler.verify
 
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSDeclaration
-import org.koin.compiler.metadata.KoinMetaData
-import org.koin.compiler.metadata.TagFactory
+import com.google.devtools.ksp.symbol.KSValueArgument
 import org.koin.compiler.resolver.getResolutionForTag
+import org.koin.compiler.resolver.isAlreadyExisting
+import org.koin.compiler.scanner.ext.getValueArgument
 
 const val codeGenerationPackage = "org.koin.ksp.generated"
 
@@ -29,75 +31,129 @@ const val codeGenerationPackage = "org.koin.ksp.generated"
  */
 class KoinConfigChecker(val logger: KSPLogger, val resolver: Resolver) {
 
-    fun verify(allModules: List<KoinMetaData.Module>) {
-        verifyDefinitionDeclarations(allModules)
-        verifyModuleIncludes(allModules)
-    }
+//    fun verify(allModules: List<KoinMetaData.Module>) {
+//        verifyDefinitionDeclarations(allModules)
+//        verifyModuleIncludes(allModules)
+//    }
 
-    private fun verifyDefinitionDeclarations(moduleList: List<KoinMetaData.Module>) {
-        val allDefinitions = moduleList.flatMap { it.definitions }
-        verifyDependencies(allDefinitions)
-    }
+//    private fun verifyDefinitionDeclarations(moduleList: List<KoinMetaData.Module>) {
+//        val allDefinitions = moduleList.flatMap { it.definitions }
+//        verifyDependencies(allDefinitions)
+//    }
 
-    private fun verifyDependencies(
-        allDefinitions: List<KoinMetaData.Definition>
-    ) {
-        allDefinitions.forEach { def ->
-            def.parameters
-                .filterIsInstance<KoinMetaData.DefinitionParameter.Dependency>()
-                .forEach { param ->
-                    checkDependency(param, def)
-                    //TODO Check Cycle
-                }
-        }
-    }
+//    private fun verifyDependencies(
+//        allDefinitions: List<KoinMetaData.Definition>
+//    ) {
+//        allDefinitions.forEach { def ->
+//            def.parameters
+//                .filterIsInstance<KoinMetaData.DefinitionParameter.Dependency>()
+//                .forEach { param ->
+//                    checkDependency(param, def)
+//                    //TODO Check Cycle
+//                }
+//        }
+//    }
 
-    private fun checkDependency(
-        param: KoinMetaData.DefinitionParameter.Dependency,
-        def: KoinMetaData.Definition
-    ) {
-        if (!param.hasDefault && !param.isNullable && !param.alreadyProvided) {
-            checkDependencyIsDefined(param, def)
-        }
-    }
+//    private fun checkDependency(
+//        param: KoinMetaData.DefinitionParameter.Dependency,
+//        def: KoinMetaData.Definition
+//    ) {
+//        if (!param.hasDefault && !param.isNullable && !param.alreadyProvided) {
+//            checkDependencyIsDefined(param, def)
+//        }
+//    }
 
 
-    private fun checkDependencyIsDefined(
-        dependencyToCheck: KoinMetaData.DefinitionParameter.Dependency,
-        definition: KoinMetaData.Definition,
-    ) {
-        val label = definition.label
-        val scope = (definition.scope as? KoinMetaData.Scope.ClassScope)?.type?.qualifiedName?.asString()
-        var targetTypeToCheck: KSDeclaration = dependencyToCheck.type.declaration
+//    private fun checkDependencyIsDefined(
+//        dependencyToCheck: KoinMetaData.DefinitionParameter.Dependency,
+//        definition: KoinMetaData.Definition,
+//    ) {
+//        val label = definition.label
+//        val scope = (definition.scope as? KoinMetaData.Scope.ClassScope)?.type?.qualifiedName?.asString()
+//        var targetTypeToCheck: KSDeclaration = dependencyToCheck.type.declaration
+//
+//        if (targetTypeToCheck.simpleName.asString() == "List" || targetTypeToCheck.simpleName.asString() == "Lazy") {
+//            targetTypeToCheck =
+//                dependencyToCheck.type.arguments.firstOrNull()?.type?.resolve()?.declaration ?: targetTypeToCheck
+//        }
+//
+//        val parameterFullName = targetTypeToCheck.qualifiedName?.asString()
+//        if (parameterFullName !in typeWhiteList && parameterFullName != null) {
+//            val cn = targetTypeToCheck.qualifiedNameCamelCase()
+//            val resolution = resolver.getResolutionForTag(cn)
+//            val isNotScopeType = scope != parameterFullName
+//            if (resolution == null && isNotScopeType) {
+//                logger.error("--> Missing Definition type '$parameterFullName' for '${definition.packageName}.$label'. Fix your configuration to define type '${targetTypeToCheck.simpleName.asString()}'.")
+//            }
+//        }
+//    }
 
-        if (targetTypeToCheck.simpleName.asString() == "List" || targetTypeToCheck.simpleName.asString() == "Lazy") {
-            targetTypeToCheck =
-                dependencyToCheck.type.arguments.firstOrNull()?.type?.resolve()?.declaration ?: targetTypeToCheck
-        }
+//    fun verifyModuleIncludes(modules: List<KoinMetaData.Module>) {
+//        modules.forEach { m ->
+//            val mn = m.packageName + "." + m.name
+//            m.includes?.forEach { inc ->
+//                val prop = resolver.getResolutionForTag(TagFactory.getTag(inc))
+//                if (prop == null) {
+//                    logger.error("--> Module Undefined :'${inc.className}' included in '$mn'. Fix your configuration: add @Module annotation on '${inc.className}' class.")
+//                }
+//            }
+//        }
+//    }
 
-        val parameterFullName = targetTypeToCheck.qualifiedName?.asString()
-        if (parameterFullName !in typeWhiteList && parameterFullName != null) {
-            val cn = targetTypeToCheck.qualifiedNameCamelCase()
-            val resolution = resolver.getResolutionForTag(cn)
-            val isNotScopeType = scope != parameterFullName
-            if (resolution == null && isNotScopeType) {
-                logger.error("--> Missing Definition type '$parameterFullName' for '${definition.packageName}.$label'. Fix your configuration to define type '${targetTypeToCheck.simpleName.asString()}'.")
+    fun verifyMetaModules(metaModules: List<KSAnnotation>) {
+        metaModules
+            .mapNotNull(::extractMetaModuleValues)
+            .forEach { (value,includes) ->
+                if (!includes.isNullOrEmpty()) verifyMetaModule(value,includes)
             }
+    }
+
+    private fun verifyMetaModule(value: String, includes: ArrayList<String>) {
+        logger.warn("verifyMetaModule: m:$value - i:$includes")
+        includes.forEach { i ->
+            val exists = resolver.isAlreadyExisting(i)
+            logger.warn("verifyMetaModule: m:$value -> $i = $exists")
+//            if (!exists) {
+//                logger.error("--> Missing Module Definition :'${i}' included in '$value'. Fix your configuration: add @Module annotation on the class.")
+//            }
         }
     }
 
-    fun verifyModuleIncludes(modules: List<KoinMetaData.Module>) {
-        modules.forEach { m ->
-            val mn = m.packageName + "." + m.name
-            m.includes?.forEach { inc ->
-                val prop = resolver.getResolutionForTag(TagFactory.getTag(inc))
-                if (prop == null) {
-                    logger.error("--> Module Undefined :'${inc.className}' included in '$mn'. Fix your configuration: add @Module annotation on '${inc.className}' class.")
-                }
+    private fun extractMetaModuleValues(a: KSAnnotation): Pair<String, ArrayList<String>?>? {
+        val value = a.arguments.getValueArgument()
+        val includes = if (value != null) a.arguments.getArray("includes") else null
+        return value?.let { it to includes }
+    }
+
+    fun verifyMetaDefinitions(metaDefinitions: List<KSAnnotation>) {
+        metaDefinitions
+            .mapNotNull(::extractMetaDefinitionValues)
+            .forEach { (value,dependencies) ->
+                logger.warn("verifyMetaDefinitions: def:$value - deps:$dependencies")
+                if (!dependencies.isNullOrEmpty()) verifyMetaDefinition(value,dependencies)
             }
+    }
+
+    private fun verifyMetaDefinition(value: String, dependencies: ArrayList<String>) {
+        logger.warn("verifyMetaDefinition: def:$value - i:$dependencies")
+        dependencies.forEach { i ->
+            val exists = resolver.isAlreadyExisting(i)
+            logger.warn("verifyMetaDefinition: def:$value -> $i = $exists")
+//            if (!exists) {
+//                logger.error("--> Missing Definition :'${i}' used by '$value'. Fix your configuration: add @Module annotation on the class.")
+//            }
         }
     }
 
+    private fun extractMetaDefinitionValues(a: KSAnnotation): Pair<String, ArrayList<String>?>? {
+        val value = a.arguments.getValueArgument()
+        val includes = if (value != null) a.arguments.getArray("dependencies") else null
+        return value?.let { it to includes }
+    }
+
+    private fun List<KSValueArgument>.getArray(name : String): ArrayList<String>? {
+        return firstOrNull { a -> a.name?.asString() == name }?.value as? ArrayList<String>?
+    }
 }
 
 internal fun KSDeclaration.qualifiedNameCamelCase() = qualifiedName?.asString()?.split(".")?.joinToString(separator = "") { it.capitalize() }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/KoinTagWriter.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/KoinTagWriter.kt
@@ -18,6 +18,8 @@ import kotlin.io.path.outputStream
 
 const val tagPrefix = "KoinDef"
 
+private const val TAG_FILE_HASH_LIMIT = 8
+
 class KoinTagWriter(val codeGenerator: CodeGenerator, val logger: KSPLogger) {
 
     lateinit var resolver: Resolver
@@ -53,7 +55,7 @@ class KoinTagWriter(val codeGenerator: CodeGenerator, val logger: KSPLogger) {
             writeDefinitionsTags(allDefinitions, it)
         }
 
-        val tagFileName = "KoinMeta-${sha256.digest().toHexString(HexFormat.Default)}"
+        val tagFileName = "KoinMeta-${sha256.digest().toHexString(HexFormat.Default).take(TAG_FILE_HASH_LIMIT)}"
         writeTagFile(tagFileName).buffered().use {
             Files.copy(tempFile, it)
         }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/ResolverExt.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/ResolverExt.kt
@@ -1,18 +1,18 @@
-package org.koin.compiler.verify.ext
+package org.koin.compiler.verify
 
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSDeclaration
 import org.koin.compiler.metadata.KoinMetaData
-import org.koin.compiler.verify.codeGenerationPackage
-import org.koin.compiler.verify.tagPrefix
+import org.koin.compiler.metadata.TagFactory
+import org.koin.compiler.metadata.tagPrefix
 
 
 fun Resolver.getResolution(mod : KoinMetaData.Module) : KSDeclaration?{
-    return getResolutionForTag(mod.getTagName())
+    return getResolutionForTag(TagFactory.getTagName(mod))
 }
 
 fun Resolver.getResolution(def : KoinMetaData.Definition) : KSDeclaration?{
-    return getResolutionForTag(def.getTagName())
+    return getResolutionForTag(TagFactory.getTagName(def))
 }
 
 fun Resolver.getResolutionForTag(tag : String?) : KSDeclaration?{

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/ResolverExt.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/ResolverExt.kt
@@ -4,19 +4,30 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSDeclaration
 import org.koin.compiler.metadata.KoinMetaData
 import org.koin.compiler.metadata.TagFactory
-import org.koin.compiler.metadata.tagPrefix
+import org.koin.compiler.metadata.TAG_PREFIX
 
+fun Resolver.isAlreadyExisting(mod : KoinMetaData.Module) : Boolean {
+    return getResolution(mod) != null
+}
 
 fun Resolver.getResolution(mod : KoinMetaData.Module) : KSDeclaration?{
-    return getResolutionForTag(TagFactory.getTagName(mod))
+    return getResolutionForTag(TagFactory.getTag(mod))
+}
+
+fun Resolver.isAlreadyExisting(def : KoinMetaData.Definition) : Boolean {
+    return getResolution(def) != null
 }
 
 fun Resolver.getResolution(def : KoinMetaData.Definition) : KSDeclaration?{
-    return getResolutionForTag(TagFactory.getTagName(def))
+    return getResolutionForTag(TagFactory.getTag(def))
+}
+
+fun Resolver.isAlreadyExisting(tag : String?) : Boolean {
+    return getResolutionForTag(tag) != null
 }
 
 fun Resolver.getResolutionForTag(tag : String?) : KSDeclaration?{
-    return getResolutionForClass("$codeGenerationPackage.$tagPrefix$tag")
+    return getResolutionForClass("$codeGenerationPackage.$TAG_PREFIX$tag")
 }
 
 fun Resolver.getResolutionForClass(name : String) : KSDeclaration?{

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/TypeWhiteList.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/TypeWhiteList.kt
@@ -9,5 +9,6 @@ internal val typeWhiteList = listOf(
     "androidx.appcompat.app.AppCompatActivity",
     "androidx.fragment.app.Fragment",
     "androidx.lifecycle.SavedStateHandle",
-    "androidx.lifecycle.ViewModel"
+    "androidx.lifecycle.ViewModel",
+    "org.koin.ktor.plugin.RequestScope"
 )


### PR DESCRIPTION
Rework all internals to generate tags, and detect it as configuration.
Rework Metadata tags, to help pull back configuration data. This helps reconsolidate the app configuration from the generated tags.