### PR TITLE
Update tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ Follow the [Koin Annotations setup page](https://insert-koin.io/docs/setup/annot
 ## Get started with Koin Tutorials 🚀
 
 You can find here tutorials to help you learn and get started with Koin framework:
-- [Kotlin](https://insert-koin.io/docs/quickstart/kotlin)
-- [Kotlin with Koin Annotations](https://insert-koin.io/docs/reference/koin-annotations/start)
-- [Android](https://insert-koin.io/docs/quickstart/android-viewmodel)
-- [Android with Koin Annotations](https://insert-koin.io/docs/quickstart/android-annotations)
-- [Android Jetpack Compose](https://insert-koin.io/docs/quickstart/android-compose)
-- [Kotlin Multiplatform](https://insert-koin.io/docs/quickstart/kmp)
-- [Ktor](https://insert-koin.io/docs/quickstart/ktor)
+- [Kotlin](https://insert-koin.io/docs/4.1/setup/koin)
+- [Kotlin with Koin Annotations](https://insert-koin.io/docs/4.1/setup/annotations)
+- [Android](https://insert-koin.io/docs/4.1/reference/koin-android/start)
+- [Android with Koin Annotations](https://insert-koin.io/docs/4.1/reference/koin-annotations/start)
+- [Android Jetpack Compose](https://insert-koin.io/docs/4.1/reference/koin-compose/compose)
+- [Kotlin Multiplatform](https://insert-koin.io/docs/4.1/reference/koin-mp/kmp)
+- [Ktor](https://insert-koin.io/docs/4.1/reference/koin-ktor/ktor)
 
 ## Latest News & Resources 🌐
 - The official Koin website: [insert-koin.io](https://insert-koin.io)

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Follow the [Koin Annotations setup page](https://insert-koin.io/docs/setup/annot
 
 You can find here tutorials to help you learn and get started with Koin framework:
 - [Kotlin](https://insert-koin.io/docs/quickstart/kotlin)
-- [Kotlin with Koin Annotations](https://insert-koin.io/docs/quickstart/kotlin-annotations)
+- [Kotlin with Koin Annotations](https://insert-koin.io/docs/reference/koin-annotations/start)
 - [Android](https://insert-koin.io/docs/quickstart/android-viewmodel)
 - [Android with Koin Annotations](https://insert-koin.io/docs/quickstart/android-annotations)
 - [Android Jetpack Compose](https://insert-koin.io/docs/quickstart/android-compose)
-- [Kotlin Multiplatform](https://insert-koin.io/docs/quickstart/kmm)
+- [Kotlin Multiplatform](https://insert-koin.io/docs/quickstart/kmp)
 - [Ktor](https://insert-koin.io/docs/quickstart/ktor)
 
 ## Latest News & Resources 🌐


### PR DESCRIPTION
The following two tutorial pages were not found:
- Kotlin with Koin Annotations
- Kotlin Multiplatform

The **Kotlin Multiplatform** page seems to have been renamed from **KMM** to **KMP**.
The **Kotlin with Koin Annotations** page is no longer listed under Quick Start.

<img width="267" alt="Screenshot 2025-03-05 at 16 32 30" src="https://github.com/user-attachments/assets/0f3c0618-867d-45cb-a169-dd56581b1fa5" />

https://insert-koin.io/docs/quickstart/kotlin

Could you confirm if the following reference is the correct page?

https://insert-koin.io/docs/reference/koin-annotations/start