### PR TITLE
feat: make @scope repeatable to configure multiple scopes

### DIFF
--- a/examples/coffee-maker-glob/src/test/java/CoffeeGlobAppTest.kt
+++ b/examples/coffee-maker-glob/src/test/java/CoffeeGlobAppTest.kt
@@ -24,6 +24,8 @@ import org.koin.example.test.scope.*
 import org.koin.ksp.generated.module
 import org.koin.mp.KoinPlatformTools
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.measureTime
 
@@ -73,10 +75,32 @@ class CoffeeGlobAppTest {
         assert(scopeS.get<MyScopedComponent3>() != scopeS.get<MyScopedComponent3>())
         assert(myScope == scopeS.get<MyScopedComponent4>().myScope)
 
-        assert(scopeS.getOrNull<AdditionalTypeScope2>() != null)
+        assert(myScope == scopeS.get<MyScopedComponentMultiScope>().myScope.value)
+        assert(myScope == scopeS.get<MyScopedComponentMultiScope2>().myScope.value)
+        assert(myScope == scopeS.get<MyScopedComponentMultiScope3>().myScope.value)
+        assert(scopeS.get<MyScopedComponentMultiScope3>() != scopeS.get<MyScopedComponentMultiScope3>())
+        assert(myScope == scopeS.get<MyScopedComponentMultiScope4>().myScope.value)
 
-        koin.createScope("_ID2_", named(MY_SCOPE_SESSION))
-            .get<MyScopedSessionComponent>()
+        assert(scopeS.getOrNull<AdditionalTypeScope2>() != null)
+        assert(scopeS.getOrNull<AdditionalTypeMultiScope2>() != null)
+
+        val myScopeSession = koin.createScope("_ID2_", named(MY_SCOPE_SESSION))
+        assertNotNull(myScopeSession.get<MyScopedSessionComponent>())
+        assertNotNull(myScopeSession.get<MyScopedSessionComponentMultiScope>())
+
+        val myAnotherScope = MyAnotherScope()
+        val anotherScopeS = koin.createScope("_ID3_", named<MyScope>(), myAnotherScope)
+        assert(myAnotherScope == anotherScopeS.get<MyScopedComponentMultiScope>().myAnotherScope.value)
+        assert(myAnotherScope == anotherScopeS.get<MyScopedComponentMultiScope2>().myAnotherScope.value)
+        assert(myAnotherScope == anotherScopeS.get<MyScopedComponentMultiScope3>().myAnotherScope.value)
+        assert(anotherScopeS.get<MyScopedComponentMultiScope3>() != anotherScopeS.get<MyScopedComponentMultiScope3>())
+        assert(myAnotherScope == anotherScopeS.get<MyScopedComponentMultiScope4>().myAnotherScope.value)
+
+        assert(anotherScopeS.getOrNull<AdditionalTypeMultiScope2>() != null)
+
+        val myScopeSession2 = koin.createScope("_ID4_", named(MY_SCOPE_SESSION2))
+        assertNull(myScopeSession2.getOrNull<MyScopedSessionComponent>())
+        assertNotNull(myScopeSession2.get<MyScopedSessionComponentMultiScope>())
 
         assert(koin.get<TestComponentConsumer3>{ parametersOf(null) }.id == null)
         assert(koin.get<TestComponentConsumer3> { parametersOf("42") }.id == "42")

--- a/examples/coffee-maker-module/src/main/kotlin/org/koin/example/test/scope/ScopeModule.kt
+++ b/examples/coffee-maker-module/src/main/kotlin/org/koin/example/test/scope/ScopeModule.kt
@@ -3,28 +3,53 @@ package org.koin.example.test.scope
 import org.koin.core.annotation.*
 
 class MyScope
+class MyAnotherScope
 interface AdditionalTypeScope
 interface AdditionalTypeScope2
+interface AdditionalTypeMultiScope
+interface AdditionalTypeMultiScope2
 
 const val MY_SCOPE_SESSION = "MY_SCOPE_SESSION"
+const val MY_SCOPE_SESSION2 = "MY_SCOPE_SESSION2"
 
 @Scope(MyScope::class)
 class MyScopedComponent(val myScope: MyScope)
+@Scope(MyScope::class)
+@Scope(MyAnotherScope::class)
+class MyScopedComponentMultiScope(@Provided val myScope: Lazy<MyScope>, @Provided val myAnotherScope: Lazy<MyAnotherScope>)
 
 class MyScopedComponent2(val myScope: MyScope)
+
+class MyScopedComponentMultiScope2(val myScope: Lazy<MyScope>, val myAnotherScope: Lazy<MyAnotherScope>)
 
 @Scope(MyScope::class)
 @Factory
 class MyScopedComponent3(val myScope: MyScope) : AdditionalTypeScope
 
 @Scope(MyScope::class)
+@Scope(MyAnotherScope::class)
+@Factory
+class MyScopedComponentMultiScope3(@Provided val myScope: Lazy<MyScope>, @Provided val myAnotherScope: Lazy<MyAnotherScope>) : AdditionalTypeMultiScope
+
+@Scope(MyScope::class)
 @Scoped(binds = [AdditionalTypeScope2::class])
 class MyScopedComponent5(val myScope: MyScope) : AdditionalTypeScope, AdditionalTypeScope2
 
+@Scope(MyScope::class)
+@Scope(MyAnotherScope::class)
+@Scoped(binds = [AdditionalTypeMultiScope2::class])
+class MyScopedComponentMultiScope5 : AdditionalTypeMultiScope, AdditionalTypeMultiScope2
+
 class MyScopedComponent4(val myScope: MyScope)
+
+class MyScopedComponentMultiScope4(val myScope: Lazy<MyScope>, val myAnotherScope: Lazy<MyAnotherScope>)
 
 @Scope(name = MY_SCOPE_SESSION)
 class MyScopedSessionComponent
+
+@Scope(name = MY_SCOPE_SESSION)
+@Scope(name = MY_SCOPE_SESSION2)
+class MyScopedSessionComponentMultiScope
 
 @Module
 @ComponentScan
@@ -34,6 +59,15 @@ class ScopeModule {
     fun myScopedComponent2(myScope: MyScope) = MyScopedComponent2(myScope)
 
     @Scope(MyScope::class)
+    @Scope(MyAnotherScope::class)
+    fun myScopedComponentMultiScope2(@Provided myScope: Lazy<MyScope>, @Provided myAnotherScope: Lazy<MyAnotherScope>) = MyScopedComponentMultiScope2(myScope, myAnotherScope)
+
+    @Scope(MyScope::class)
     @Factory
     fun myScopedComponent4(myScope: MyScope) = MyScopedComponent4(myScope)
+
+    @Scope(MyScope::class)
+    @Scope(MyAnotherScope::class)
+    @Factory
+    fun myScopedComponentMultiScope4(@Provided myScope: Lazy<MyScope>, @Provided myAnotherScope: Lazy<MyAnotherScope>) = MyScopedComponentMultiScope4(myScope, myAnotherScope)
 }

--- a/examples/coffee-maker/src/test/java/CoffeeAppTest.kt
+++ b/examples/coffee-maker/src/test/java/CoffeeAppTest.kt
@@ -21,6 +21,7 @@ import org.koin.example.test.include.IncludedComponent
 import org.koin.example.test.scope.*
 import org.koin.ksp.generated.module
 import org.koin.mp.KoinPlatformTools
+import kotlin.test.*
 import kotlin.time.measureTime
 
 class CoffeeAppTest {
@@ -72,8 +73,48 @@ class CoffeeAppTest {
 
         assert(scopeS.getOrNull<AdditionalTypeScope2>() != null)
 
-        koin.createScope("_ID2_", named(MY_SCOPE_SESSION))
-            .get<MyScopedSessionComponent>()
+        val myScopeSession = koin.createScope("_ID2_", named(MY_SCOPE_SESSION))
+        assertNotNull(myScopeSession.getOrNull<MyScopedSessionComponent>())
+
+        // BEGIN MUltiScope
+        val myAnotherScope = MyAnotherScope()
+        val anotherScopeS = koin.createScope("_ID3_", named<MyAnotherScope>(), myAnotherScope)
+        assertEquals(myScope, scopeS.get<MyScopedComponentMultiScope>().myScope.value)
+        assertFails { scopeS.get<MyScopedComponentMultiScope>().myAnotherScope.value }
+        assertEquals(myAnotherScope, anotherScopeS.get<MyScopedComponentMultiScope>().myAnotherScope.value)
+        assertFails { anotherScopeS.get<MyScopedComponentMultiScope>().myScope.value }
+
+        assertEquals(myScope, scopeS.get<MyScopedComponentMultiScope2>().myScope.value)
+        assertFails { scopeS.get<MyScopedComponentMultiScope2>().myAnotherScope.value }
+        assertEquals(myAnotherScope, anotherScopeS.get<MyScopedComponentMultiScope2>().myAnotherScope.value)
+        assertFails { anotherScopeS.get<MyScopedComponentMultiScope2>().myScope.value }
+
+        assertEquals(myScope, scopeS.get<MyScopedComponentMultiScope3>().myScope.value)
+        assertFails { scopeS.get<MyScopedComponentMultiScope3>().myAnotherScope.value }
+        assertEquals(myAnotherScope, anotherScopeS.get<MyScopedComponentMultiScope3>().myAnotherScope.value)
+        assertFails { anotherScopeS.get<MyScopedComponentMultiScope3>().myScope.value }
+        assertNotEquals(scopeS.get<MyScopedComponentMultiScope3>(), scopeS.get<MyScopedComponentMultiScope3>())
+        assertNotEquals(anotherScopeS.get<MyScopedComponentMultiScope3>(), anotherScopeS.get<MyScopedComponentMultiScope3>())
+
+        assertEquals(myScope, scopeS.get<MyScopedComponentMultiScope4>().myScope.value)
+        assertFails { scopeS.get<MyScopedComponentMultiScope4>().myAnotherScope.value }
+        assertEquals(myAnotherScope, anotherScopeS.get<MyScopedComponentMultiScope4>().myAnotherScope.value)
+        assertFails { anotherScopeS.get<MyScopedComponentMultiScope4>().myScope.value }
+        assertNotEquals(scopeS.get<MyScopedComponentMultiScope4>(), scopeS.get<MyScopedComponentMultiScope4>())
+        assertNotEquals(anotherScopeS.get<MyScopedComponentMultiScope4>(), anotherScopeS.get<MyScopedComponentMultiScope4>())
+
+        assertNotNull(scopeS.getOrNull<AdditionalTypeMultiScope>())
+        assertNotNull(anotherScopeS.getOrNull<AdditionalTypeMultiScope>())
+
+        assertNotNull(scopeS.getOrNull<AdditionalTypeMultiScope2>())
+        assertSame(scopeS.getOrNull<AdditionalTypeMultiScope2>(), scopeS.getOrNull<MyScopedComponentMultiScope5>())
+        assertNotNull(anotherScopeS.getOrNull<AdditionalTypeMultiScope2>())
+        assertSame(anotherScopeS.getOrNull<AdditionalTypeMultiScope2>(), anotherScopeS.getOrNull<MyScopedComponentMultiScope5>())
+
+        assertNotNull(myScopeSession.getOrNull<MyScopedSessionComponentMultiScope>())
+        val myScopeSession2 = koin.createScope("_ID4_", named(MY_SCOPE_SESSION2))
+        assertNotNull(myScopeSession2.getOrNull<MyScopedSessionComponentMultiScope>())
+        // END MUltiScope
 
         assert(koin.get<TestComponentConsumer3>{ parametersOf(null) }.id == null)
         assert(koin.get<TestComponentConsumer3>{ parametersOf("42") }.id == "42")

--- a/projects/koin-annotations/src/commonMain/kotlin/org/koin/core/annotation/CoreAnnotations.kt
+++ b/projects/koin-annotations/src/commonMain/kotlin/org/koin/core/annotation/CoreAnnotations.kt
@@ -74,6 +74,7 @@ annotation class Factory(val binds: Array<KClass<*>> = [Unit::class])
  * example:
  *
  * @Scope(MyScope::class)
+ * @Scope(MyAnotherScope::class)
  * class MyClass(val d : MyDependency)
  *
  * will generate:
@@ -81,11 +82,15 @@ annotation class Factory(val binds: Array<KClass<*>> = [Unit::class])
  * scope<MyScope> {
  *  scoped { MyClass(get()) }
  * }
+ * scope<MyAnotherScope> {
+ *  scoped { MyClass(get()) }
+ * }
  * ```
  *
  * @param value: scope class value
  * @param name: scope string value
  */
+@Repeatable
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 annotation class Scope(val value: KClass<*> = Unit::class, val name: String = "")
 

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/AnnotationMetadata.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/AnnotationMetadata.kt
@@ -55,7 +55,7 @@ fun isValidAnnotation(s: String): Boolean = s.lowercase(Locale.getDefault()) in 
 fun isValidScopeExtraAnnotation(s: String): Boolean = s.lowercase(Locale.getDefault()) in SCOPE_DEFINITION_ANNOTATION_LIST_NAMES
 fun isScopeAnnotation(s: String): Boolean = s.lowercase(Locale.getDefault()) == SCOPE.annotationName?.lowercase(Locale.getDefault())
 
-fun getExtraScopeAnnotation(annotations: Map<String, KSAnnotation>): DefinitionAnnotation? {
+fun getExtraScopeAnnotation(annotations: Map<String, List<KSAnnotation>>): DefinitionAnnotation? {
     val key = annotations.keys.firstOrNull { k -> isValidScopeExtraAnnotation(k) }
     val definitionAnnotation = when (key) {
         SCOPED.annotationName -> SCOPED

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/FunctionScanner.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/FunctionScanner.kt
@@ -38,7 +38,7 @@ abstract class FunctionScanner(
         qualifier: String?,
         functionName: String,
         ksFunctionDeclaration: KSFunctionDeclaration,
-        annotations: Map<String, KSAnnotation> = emptyMap()
+        annotations: Map<String, List<KSAnnotation>> = emptyMap()
     ): KoinMetaData.Definition.FunctionDefinition? {
         val foundBindings: List<KSDeclaration> = declaredBindings(annotation)?.let { if (!it.hasDefaultUnitValue()) it else emptyList() } ?: emptyList()
         val returnedType: KSDeclaration? = ksFunctionDeclaration.returnType?.resolve()?.declaration

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/KoinMetaDataScanner.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/KoinMetaDataScanner.kt
@@ -154,8 +154,8 @@ class KoinMetaDataScanner(
 
         val definitions = resolver.getValidDefinitionSymbols()
             .filterIsInstance<KSFunctionDeclaration>()
-            .mapNotNull { functionMetadataScanner.createFunctionDefinition(it) }
-            .toList()
+            .mapNotNull { functionMetadataScanner.createFunctionDefinitions(it) }
+            .flatten()
 
         definitions.forEach { addToModule(it, defaultModule, scanComponentIndex) }
         return definitions
@@ -170,8 +170,7 @@ class KoinMetaDataScanner(
 
         val definitions = resolver.getValidDefinitionSymbols()
             .filterIsInstance<KSClassDeclaration>()
-            .map { componentMetadataScanner.createClassDefinition(it) }
-            .toList()
+            .flatMap { componentMetadataScanner.createClassDefinitions(it) }
         definitions.forEach { addToModule(it, defaultModule, scanComponentIndex) }
         return definitions
     }

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/ext/KspExt.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/ext/KspExt.kt
@@ -22,16 +22,15 @@ import org.koin.compiler.metadata.isValidAnnotation
 import org.koin.compiler.type.forbiddenKeywords
 import org.koin.core.annotation.*
 
-fun KSAnnotated.getKoinAnnotations(): Map<String, KSAnnotation> {
+fun KSAnnotated.getKoinAnnotations(): Map<String, List<KSAnnotation>> {
     return annotations
         .filter { isValidAnnotation(it.shortName.asString()) }
-        .map { annotation -> Pair(annotation.shortName.asString(), annotation) }
-        .toMap()
+        .groupBy { it.shortName.asString() }
 }
 
-fun Map<String, KSAnnotation>.getScopeAnnotation(): Pair<String, KSAnnotation>? {
-    return firstNotNullOfOrNull { (name, annotation) ->
-        if (isScopeAnnotation(name)) Pair(name, annotation) else null
+fun Map<String, List<KSAnnotation>>.getScopeAnnotations(): Pair<String, List<KSAnnotation>>? {
+    return firstNotNullOfOrNull { (name, annotations) ->
+        if (isScopeAnnotation(name)) Pair(name, annotations) else null
     }
 }
 


### PR DESCRIPTION
make @Scope repeatable to configure multiple scopes
e.g.
```kotlin
@Scope(MyScope::class)
@Scope(MyAnotherScope::class)
class MyClass(val d : MyDependency)
```
will generate:
```kotlin
scope<MyScope> { 
     scoped { MyClass(get()) }
}
scope<MyAnotherScope> {
     scoped { MyClass(get()) } 
}
```