### PR TITLE
Fix cycle detection up and down

### DIFF
--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/KoinConfigChecker.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/verify/KoinConfigChecker.kt
@@ -178,11 +178,10 @@ class KoinConfigChecker(val logger: KSPLogger, val resolver: Resolver) {
         
         // If we've seen this node before, we have a cycle
         if (currentDefinition.value in visited) {
-            // Only report if it's a cycle back to the origin
-            if (currentDefinition.value == originDefinition.value) {
-                val cyclePath = visited.joinToString(" -> ") + " -> " + currentDefinition.value
-                logger.error("---> Cycle detected: $cyclePath")
-            }
+            // Report any cycle, not just back to origin
+            val cycleStart = visited.toList().indexOf(currentDefinition.value)
+            val cyclePath = visited.toList().subList(cycleStart, visited.size).joinToString(" -> ") + " -> " + currentDefinition.value
+            logger.error("---> Cycle detected: $cyclePath")
             return
         }
         
@@ -201,4 +200,4 @@ class KoinConfigChecker(val logger: KSPLogger, val resolver: Resolver) {
     }
 }
 
-internal fun KSDeclaration.qualifiedNameCamelCase() = qualifiedName?.asString()?.split(".")?.joinToString(separator = "") { it.capitalize() }
+internal fun KSDeclaration.qualifiedNameCamelCase() = qualifiedName?.asString()?.split(".")?.joinToString(separator = "") { it.replaceFirstChar { it.uppercase() } }


### PR DESCRIPTION
Now detects all cycles in the dependency graph, not just those back to the origin:
  1. Finds the cycle start point using indexOf()
  2. Extracts only the cyclic portion with subList()
  3. Reports the actual cycle path instead of the full traversal path

  Example:
  - Before: Only reported A -> B -> C -> A
  - After: Also reports intermediate cycles like B -> C -> D -> B

Delivered in release `2.1.1-Beta1`
