### PR TITLE
Use qualified name instead of package + simple name for module def

### DIFF
--- a/examples/other-ksp/src/main/kotlin/org/koin/example/supertype/Types.kt
+++ b/examples/other-ksp/src/main/kotlin/org/koin/example/supertype/Types.kt
@@ -21,5 +21,9 @@ public class C : B(),D
 class MyType {
 
     @Single
-    class MyChildType
+    class MyChildType {
+        @Single
+        class MyGrandChildType
+    }
+
 }

--- a/examples/other-ksp/src/test/kotlin/org.koin.example/TestModule.kt
+++ b/examples/other-ksp/src/test/kotlin/org.koin.example/TestModule.kt
@@ -129,7 +129,8 @@ class TestModule {
         assertEquals(2,koin.get<StuffList>(named("another-counter")).list.size)
         assertEquals("another-counter",koin.get<StuffCounter>().name)
 
-        assertNotNull(koin.getOrNull<MyType.MyChildType>())
+        assertNotNull(koin.getOrNull<MyType.MyChild>())
+        assertNotNull(koin.getOrNull<MyType.MyChild.MyGrandChildType>())
     }
 
 

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/DefinitionWriterFactory.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/generator/DefinitionWriterFactory.kt
@@ -48,7 +48,7 @@ class DefinitionWriterFactory(
                 }
             }
             // Class
-            is KoinMetaData.Definition.ClassDefinition -> writer.writeDefinition(definition, prefix = "${definition.packageNamePrefix}${definition.className}", isExternalDefinition = isExternal ?: false)
+            is KoinMetaData.Definition.ClassDefinition -> writer.writeDefinition(definition, prefix = definition.qualifiedName, isExternalDefinition = isExternal ?: false)
         }
     }
 

--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinMetaData.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/metadata/KoinMetaData.kt
@@ -203,14 +203,14 @@ sealed class KoinMetaData {
             qualifier: String?,
             isCreatedAtStart: Boolean? = null,
             keyword: DefinitionAnnotation,
-            val className: String,
+            val qualifiedName: String,
             val constructorParameters: List<DefinitionParameter> = emptyList(),
             bindings: List<KSDeclaration>,
             scope: Scope? = null,
             isExpect : Boolean,
             isActual : Boolean
         ) : Definition(
-            className,
+            qualifiedName,
             constructorParameters,
             packageName,
             qualifier,


### PR DESCRIPTION
The fix in #297  only looks one parent up. This will get the full path regardless of nested layers. 

Since the only place the class name was used was in the prefix, I thought it best to just remove the manual concatenation
and just used the qualified name
