### PR TITLE
Fix including module error when package name contains forbidden keywords

### DIFF
--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/ModuleScanner.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/ModuleScanner.kt
@@ -110,7 +110,7 @@ class ModuleScanner(
     }
 
     private fun KSDeclaration.mapModuleInclude(): KoinMetaData.ModuleInclude {
-        val packageName: String = packageName.asString()
+        val packageName: String = packageName.asString().filterForbiddenKeywords()
         val className = simpleName.asString()
         return KoinMetaData.ModuleInclude(packageName, className, isExpect, isActual)
     }


### PR DESCRIPTION
This PR fixes error which failed to generate module files correctly when package name contains forbidden keywords

### Steps to reproduce
1. Create an empty CMP project with a package name that contains a forbidden keyword (e.g., in).
2. Add koin-annotations.
3. Create modules like below.
```
@Module(includes = [FirstModule::class, SecondModule::class])
class AppModule

@Module
class FirstModule

@Module
class SecondModule
```
4. Build the project.

Before the fix (koin-annotations 2.1.0),  AppModuleGen is generated as follows:
```
public val in_jetbrains_kmpapp_di_AppModule : Module get() = module {
	includes(in.jetbrains.kmpapp.di.FirstModule().module,in.jetbrains.kmpapp.di.SecondModule().module)
}
public val `in`.jetbrains.kmpapp.di.AppModule.module : org.koin.core.module.Module get() = in_jetbrains_kmpapp_di_AppModule
```

After this fix, AppModuleGen is generated correctly as shown below:
```
public val in_jetbrains_kmpapp_di_AppModule : Module get() = module {
	includes(`in`.jetbrains.kmpapp.di.FirstModule().module,`in`.jetbrains.kmpapp.di.SecondModule().module)
}
public val `in`.jetbrains.kmpapp.di.AppModule.module : org.koin.core.module.Module get() = in_jetbrains_kmpapp_di_AppModule
```