### PR TITLE
Fix issue where binds = [] has no effect

### DIFF
--- a/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/ClassComponentScanner.kt
+++ b/projects/koin-ksp-compiler/src/jvmMain/kotlin/org/koin/compiler/scanner/ClassComponentScanner.kt
@@ -63,7 +63,7 @@ class ClassComponentScanner(
     ): KoinMetaData.Definition.ClassDefinition {
         val declaredBindings = declaredBindings(annotation)
         val defaultBindings = ksClassDeclaration.superTypes.map { it.resolve().declaration }.toList()
-        val forceDeclaredBindings = declaredBindings?.hasDefaultUnitValue() == false && declaredBindings.isNotEmpty()
+        val forceDeclaredBindings = declaredBindings?.hasDefaultUnitValue() == false
         val allBindings: List<KSDeclaration> = if (forceDeclaredBindings) declaredBindings else defaultBindings
 
         val ctorParams = ksClassDeclaration.primaryConstructor?.parameters?.getParameters()


### PR DESCRIPTION
`@Single(binds = [])` and `@Factory(binds = [])` are expected to clear all bindings,
but currently, all supertypes are still registered.

To resolve this, remove the `isNotEmpty()` check from the `forceDeclaredBindings` condition
so that an empty binds array works as intended.