### PR TITLE
Add watchosDeviceArm64 target to koin-annotations build.gradle.kts

### DIFF
--- a/projects/koin-annotations/build.gradle.kts
+++ b/projects/koin-annotations/build.gradle.kts
@@ -27,6 +27,7 @@ kotlin {
     macosArm64()
     watchosArm32()
     watchosArm64()
+    watchosDeviceArm64()
     watchosSimulatorArm64()
     watchosX64()
     tvosArm64()


### PR DESCRIPTION
In April 2026 WatchOS will require Arm64 as an architecture.

Whilst `watchosArm64()` is already listed, I believe it only adds support for Arm64_32.

I believe `watchosDeviceArm64()` will be required for Arm64

I'm not sure if there are other changes required for this PR!
May also need adding to [koin-jsr330/build.gradle.kts](https://github.com/InsertKoinIO/koin-annotations/blob/main/projects/koin-jsr330/build.gradle.kts)